### PR TITLE
[Refactor/151] 카테고리 색상 enum class로 관리

### DIFF
--- a/app/src/main/java/com/mongmong/namo/data/local/entity/custom/Palette.kt
+++ b/app/src/main/java/com/mongmong/namo/data/local/entity/custom/Palette.kt
@@ -2,5 +2,5 @@ package com.mongmong.namo.data.local.entity.custom
 
 data class Palette(
     var name: String,
-    val colors: IntArray
+    val colors: ArrayList<String> // hexColor
 )

--- a/app/src/main/java/com/mongmong/namo/data/local/entity/home/Category.kt
+++ b/app/src/main/java/com/mongmong/namo/data/local/entity/home/Category.kt
@@ -10,7 +10,7 @@ import java.io.Serializable
 data class Category(
     @PrimaryKey(autoGenerate = true) val categoryId: Long = 0,
     var name : String = "",
-    var color : Int = 0,
+    var paletteId : Int = 0,
     var share : Boolean = false,
     var active : Boolean = true,
     var isUpload : Boolean = false,

--- a/app/src/main/java/com/mongmong/namo/presentation/config/CategoryColor.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/config/CategoryColor.kt
@@ -4,31 +4,31 @@ import android.content.res.ColorStateList
 import android.graphics.Color
 import com.mongmong.namo.R
 
-enum class BelongType { BELONG1, BELONG2 }
+enum class PaletteType { DEFAULT_4, BASIC_PALETTE }
 
 /** 내부 색상 저장 용도 */
-enum class CategoryColor(val belongType: BelongType, val paletteId: Int, val hexColor: String, val intColor: Int) {
+enum class CategoryColor(val paletteType: PaletteType, val paletteId: Int, val hexColor: String, val intColor: Int) {
     /** 기본 색상 */
-    SCHEDULE(BelongType.BELONG1, 1, "#DE8989", R.color.schedule),
-    YELLOW(BelongType.BELONG1, 2, "#E1B000", R.color.schedule_plan),
-    BLUE(BelongType.BELONG1, 3, "#5C8596", R.color.schedule_parttime),
-    MOIM(BelongType.BELONG1, 4, "#DA6022", R.color.schedule_group),
+    SCHEDULE(PaletteType.DEFAULT_4, 1, "#DE8989", R.color.schedule),
+    YELLOW(PaletteType.DEFAULT_4, 2, "#E1B000", R.color.schedule_plan),
+    BLUE(PaletteType.DEFAULT_4, 3, "#5C8596", R.color.schedule_parttime),
+    MOIM(PaletteType.DEFAULT_4, 4, "#DA6022", R.color.schedule_group),
     /** 기본 팔레트 */
-    DEFAULT_PALETTE_COLOR1(BelongType.BELONG2, 5, "#EB5353", R.color.palette1),
-    DEFAULT_PALETTE_COLOR2(BelongType.BELONG2, 6, "#EC9B3B", R.color.palette2),
-    DEFAULT_PALETTE_COLOR3(BelongType.BELONG2, 7, "#FBCB0A", R.color.palette3),
-    DEFAULT_PALETTE_COLOR4(BelongType.BELONG2, 8, "#96BB7C", R.color.palette4),
-    DEFAULT_PALETTE_COLOR5(BelongType.BELONG2, 9, "#5A8F7B", R.color.palette5),
-    DEFAULT_PALETTE_COLOR6(BelongType.BELONG2, 10, "#82C4C3", R.color.palette6),
-    DEFAULT_PALETTE_COLOR7(BelongType.BELONG2, 11, "#187498", R.color.palette7),
-    DEFAULT_PALETTE_COLOR8(BelongType.BELONG2, 12, "#8571BF", R.color.palette8),
-    DEFAULT_PALETTE_COLOR9(BelongType.BELONG2, 13, "#E36488", R.color.palette9),
-    DEFAULT_PALETTE_COLOR10(BelongType.BELONG2, 14, "#858585", R.color.palette10);
+    DEFAULT_PALETTE_COLOR1(PaletteType.BASIC_PALETTE, 5, "#EB5353", R.color.palette1),
+    DEFAULT_PALETTE_COLOR2(PaletteType.BASIC_PALETTE, 6, "#EC9B3B", R.color.palette2),
+    DEFAULT_PALETTE_COLOR3(PaletteType.BASIC_PALETTE, 7, "#FBCB0A", R.color.palette3),
+    DEFAULT_PALETTE_COLOR4(PaletteType.BASIC_PALETTE, 8, "#96BB7C", R.color.palette4),
+    DEFAULT_PALETTE_COLOR5(PaletteType.BASIC_PALETTE, 9, "#5A8F7B", R.color.palette5),
+    DEFAULT_PALETTE_COLOR6(PaletteType.BASIC_PALETTE, 10, "#82C4C3", R.color.palette6),
+    DEFAULT_PALETTE_COLOR7(PaletteType.BASIC_PALETTE, 11, "#187498", R.color.palette7),
+    DEFAULT_PALETTE_COLOR8(PaletteType.BASIC_PALETTE, 12, "#8571BF", R.color.palette8),
+    DEFAULT_PALETTE_COLOR9(PaletteType.BASIC_PALETTE, 13, "#E36488", R.color.palette9),
+    DEFAULT_PALETTE_COLOR10(PaletteType.BASIC_PALETTE, 14, "#858585", R.color.palette10);
 
     companion object {
         // BelongType에 해당하는 리스트 반환
-        fun findPalettes(belongType: BelongType): ArrayList<CategoryColor> {
-            return values().filter { it.belongType == belongType } as ArrayList<CategoryColor>
+        fun findPalettes(paletteType: PaletteType): ArrayList<CategoryColor> {
+            return values().filter { it.paletteType == paletteType } as ArrayList<CategoryColor>
         }
 
         // paletteId로 CategoryColor 찾기

--- a/app/src/main/java/com/mongmong/namo/presentation/config/CategoryColor.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/config/CategoryColor.kt
@@ -2,33 +2,42 @@ package com.mongmong.namo.presentation.config
 
 import android.content.res.ColorStateList
 import android.graphics.Color
-import com.mongmong.namo.R
 
 enum class PaletteType { DEFAULT_4, BASIC_PALETTE }
 
 /** 내부 색상 저장 용도 */
-enum class CategoryColor(val paletteType: PaletteType, val paletteId: Int, val hexColor: String, val intColor: Int) {
+enum class CategoryColor(val paletteType: PaletteType, val paletteId: Int, val hexColor: String) {
     /** 기본 색상 */
-    SCHEDULE(PaletteType.DEFAULT_4, 1, "#DE8989", R.color.schedule),
-    YELLOW(PaletteType.DEFAULT_4, 2, "#E1B000", R.color.schedule_plan),
-    BLUE(PaletteType.DEFAULT_4, 3, "#5C8596", R.color.schedule_parttime),
-    MOIM(PaletteType.DEFAULT_4, 4, "#DA6022", R.color.schedule_group),
+    SCHEDULE(PaletteType.DEFAULT_4, 1, "#DE8989"),
+    YELLOW(PaletteType.DEFAULT_4, 2, "#E1B000"),
+    BLUE(PaletteType.DEFAULT_4, 3, "#5C8596"),
+    MOIM(PaletteType.DEFAULT_4, 4, "#DA6022"),
     /** 기본 팔레트 */
-    DEFAULT_PALETTE_COLOR1(PaletteType.BASIC_PALETTE, 5, "#EB5353", R.color.palette1),
-    DEFAULT_PALETTE_COLOR2(PaletteType.BASIC_PALETTE, 6, "#EC9B3B", R.color.palette2),
-    DEFAULT_PALETTE_COLOR3(PaletteType.BASIC_PALETTE, 7, "#FBCB0A", R.color.palette3),
-    DEFAULT_PALETTE_COLOR4(PaletteType.BASIC_PALETTE, 8, "#96BB7C", R.color.palette4),
-    DEFAULT_PALETTE_COLOR5(PaletteType.BASIC_PALETTE, 9, "#5A8F7B", R.color.palette5),
-    DEFAULT_PALETTE_COLOR6(PaletteType.BASIC_PALETTE, 10, "#82C4C3", R.color.palette6),
-    DEFAULT_PALETTE_COLOR7(PaletteType.BASIC_PALETTE, 11, "#187498", R.color.palette7),
-    DEFAULT_PALETTE_COLOR8(PaletteType.BASIC_PALETTE, 12, "#8571BF", R.color.palette8),
-    DEFAULT_PALETTE_COLOR9(PaletteType.BASIC_PALETTE, 13, "#E36488", R.color.palette9),
-    DEFAULT_PALETTE_COLOR10(PaletteType.BASIC_PALETTE, 14, "#858585", R.color.palette10);
+    DEFAULT_PALETTE_COLOR1(PaletteType.BASIC_PALETTE, 5, "#EB5353"),
+    DEFAULT_PALETTE_COLOR2(PaletteType.BASIC_PALETTE, 6, "#EC9B3B"),
+    DEFAULT_PALETTE_COLOR3(PaletteType.BASIC_PALETTE, 7, "#FBCB0A"),
+    DEFAULT_PALETTE_COLOR4(PaletteType.BASIC_PALETTE, 8, "#96BB7C"),
+    DEFAULT_PALETTE_COLOR5(PaletteType.BASIC_PALETTE, 9, "#5A8F7B"),
+    DEFAULT_PALETTE_COLOR6(PaletteType.BASIC_PALETTE, 10, "#82C4C3"),
+    DEFAULT_PALETTE_COLOR7(PaletteType.BASIC_PALETTE, 11, "#187498"),
+    DEFAULT_PALETTE_COLOR8(PaletteType.BASIC_PALETTE, 12, "#8571BF"),
+    DEFAULT_PALETTE_COLOR9(PaletteType.BASIC_PALETTE, 13, "#E36488"),
+    DEFAULT_PALETTE_COLOR10(PaletteType.BASIC_PALETTE, 14, "#858585");
 
     companion object {
-        // BelongType에 해당하는 리스트 반환
-        fun findPalettes(paletteType: PaletteType): ArrayList<CategoryColor> {
+        // enum class의 모든 hexColor 반환
+        fun getAllColors(): ArrayList<String> {
+            return values().map { it.hexColor } as ArrayList<String>
+        }
+
+        // PaletteType에 해당하는 리스트 반환
+        fun findPaletteByPaletteType(paletteType: PaletteType): ArrayList<CategoryColor> {
             return values().filter { it.paletteType == paletteType } as ArrayList<CategoryColor>
+        }
+
+        // 팔레트의 hexColor만 반환하기
+        fun findColorsByPaletteType(paletteType: PaletteType): ArrayList<String> {
+            return findPaletteByPaletteType(paletteType).map { it.hexColor } as ArrayList<String>
         }
 
         // paletteId로 CategoryColor 찾기

--- a/app/src/main/java/com/mongmong/namo/presentation/config/CategoryColor.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/config/CategoryColor.kt
@@ -2,7 +2,7 @@ package com.mongmong.namo.presentation.config
 
 enum class BelongType { BELONG1, BELONG2 }
 
-enum class CategoryColor(val belongType: BelongType, val paletteId: Int, val hexCode: String) {
+enum class CategoryColor(val belongType: BelongType, val paletteId: Int, val hexColor: String) {
     /** 기본 색상 */
     SCHEDULE(BelongType.BELONG1, 1, "#DE8989"),
     YELLOW(BelongType.BELONG1, 2, "#E1B000"),
@@ -18,5 +18,11 @@ enum class CategoryColor(val belongType: BelongType, val paletteId: Int, val hex
     DEFAULT_PALETTE_COLOR7(BelongType.BELONG2, 11, "#187498"),
     DEFAULT_PALETTE_COLOR8(BelongType.BELONG2, 12, "#8571BF"),
     DEFAULT_PALETTE_COLOR9(BelongType.BELONG2, 13, "#E36488"),
-    DEFAULT_PALETTE_COLOR10(BelongType.BELONG2, 14, "#858585"),
+    DEFAULT_PALETTE_COLOR10(BelongType.BELONG2, 14, "#858585");
+
+    companion object {
+        fun convertPaletteIdToHexColor(paletteId: Int): String { // hexColor를 반환
+            return CategoryColor.values().find { it.paletteId == paletteId }?.hexColor ?: ""
+        }
+    }
 }

--- a/app/src/main/java/com/mongmong/namo/presentation/config/CategoryColor.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/config/CategoryColor.kt
@@ -1,0 +1,22 @@
+package com.mongmong.namo.presentation.config
+
+enum class BelongType { BELONG1, BELONG2 }
+
+enum class CategoryColor(val belongType: BelongType, val paletteId: Int, val hexCode: String) {
+    /** 기본 색상 */
+    SCHEDULE(BelongType.BELONG1, 1, "#DE8989"),
+    YELLOW(BelongType.BELONG1, 2, "#E1B000"),
+    BLUE(BelongType.BELONG1, 3, "#5C8596"),
+    MOIM(BelongType.BELONG1, 4, "#DA6022"),
+    /** 기본 팔레트 */
+    DEFAULT_PALETTE_COLOR1(BelongType.BELONG2, 5, "#EB5353"),
+    DEFAULT_PALETTE_COLOR2(BelongType.BELONG2, 6, "#EC9B3B"),
+    DEFAULT_PALETTE_COLOR3(BelongType.BELONG2, 7, "#FBCB0A"),
+    DEFAULT_PALETTE_COLOR4(BelongType.BELONG2, 8, "#96BB7C"),
+    DEFAULT_PALETTE_COLOR5(BelongType.BELONG2, 9, "#5A8F7B"),
+    DEFAULT_PALETTE_COLOR6(BelongType.BELONG2, 10, "#82C4C3"),
+    DEFAULT_PALETTE_COLOR7(BelongType.BELONG2, 11, "#187498"),
+    DEFAULT_PALETTE_COLOR8(BelongType.BELONG2, 12, "#8571BF"),
+    DEFAULT_PALETTE_COLOR9(BelongType.BELONG2, 13, "#E36488"),
+    DEFAULT_PALETTE_COLOR10(BelongType.BELONG2, 14, "#858585"),
+}

--- a/app/src/main/java/com/mongmong/namo/presentation/config/CategoryColor.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/config/CategoryColor.kt
@@ -1,28 +1,54 @@
 package com.mongmong.namo.presentation.config
 
+import android.content.res.ColorStateList
+import android.graphics.Color
+import com.mongmong.namo.R
+
 enum class BelongType { BELONG1, BELONG2 }
 
-enum class CategoryColor(val belongType: BelongType, val paletteId: Int, val hexColor: String) {
+/** 내부 색상 저장 용도 */
+enum class CategoryColor(val belongType: BelongType, val paletteId: Int, val hexColor: String, val intColor: Int) {
     /** 기본 색상 */
-    SCHEDULE(BelongType.BELONG1, 1, "#DE8989"),
-    YELLOW(BelongType.BELONG1, 2, "#E1B000"),
-    BLUE(BelongType.BELONG1, 3, "#5C8596"),
-    MOIM(BelongType.BELONG1, 4, "#DA6022"),
+    SCHEDULE(BelongType.BELONG1, 1, "#DE8989", R.color.schedule),
+    YELLOW(BelongType.BELONG1, 2, "#E1B000", R.color.schedule_plan),
+    BLUE(BelongType.BELONG1, 3, "#5C8596", R.color.schedule_parttime),
+    MOIM(BelongType.BELONG1, 4, "#DA6022", R.color.schedule_group),
     /** 기본 팔레트 */
-    DEFAULT_PALETTE_COLOR1(BelongType.BELONG2, 5, "#EB5353"),
-    DEFAULT_PALETTE_COLOR2(BelongType.BELONG2, 6, "#EC9B3B"),
-    DEFAULT_PALETTE_COLOR3(BelongType.BELONG2, 7, "#FBCB0A"),
-    DEFAULT_PALETTE_COLOR4(BelongType.BELONG2, 8, "#96BB7C"),
-    DEFAULT_PALETTE_COLOR5(BelongType.BELONG2, 9, "#5A8F7B"),
-    DEFAULT_PALETTE_COLOR6(BelongType.BELONG2, 10, "#82C4C3"),
-    DEFAULT_PALETTE_COLOR7(BelongType.BELONG2, 11, "#187498"),
-    DEFAULT_PALETTE_COLOR8(BelongType.BELONG2, 12, "#8571BF"),
-    DEFAULT_PALETTE_COLOR9(BelongType.BELONG2, 13, "#E36488"),
-    DEFAULT_PALETTE_COLOR10(BelongType.BELONG2, 14, "#858585");
+    DEFAULT_PALETTE_COLOR1(BelongType.BELONG2, 5, "#EB5353", R.color.palette1),
+    DEFAULT_PALETTE_COLOR2(BelongType.BELONG2, 6, "#EC9B3B", R.color.palette2),
+    DEFAULT_PALETTE_COLOR3(BelongType.BELONG2, 7, "#FBCB0A", R.color.palette3),
+    DEFAULT_PALETTE_COLOR4(BelongType.BELONG2, 8, "#96BB7C", R.color.palette4),
+    DEFAULT_PALETTE_COLOR5(BelongType.BELONG2, 9, "#5A8F7B", R.color.palette5),
+    DEFAULT_PALETTE_COLOR6(BelongType.BELONG2, 10, "#82C4C3", R.color.palette6),
+    DEFAULT_PALETTE_COLOR7(BelongType.BELONG2, 11, "#187498", R.color.palette7),
+    DEFAULT_PALETTE_COLOR8(BelongType.BELONG2, 12, "#8571BF", R.color.palette8),
+    DEFAULT_PALETTE_COLOR9(BelongType.BELONG2, 13, "#E36488", R.color.palette9),
+    DEFAULT_PALETTE_COLOR10(BelongType.BELONG2, 14, "#858585", R.color.palette10);
 
     companion object {
-        fun convertPaletteIdToHexColor(paletteId: Int): String { // hexColor를 반환
-            return CategoryColor.values().find { it.paletteId == paletteId }?.hexColor ?: ""
+        // BelongType에 해당하는 리스트 반환
+        fun findPalettes(belongType: BelongType): ArrayList<CategoryColor> {
+            return values().filter { it.belongType == belongType } as ArrayList<CategoryColor>
+        }
+
+        // paletteId로 CategoryColor 찾기
+        fun findCategoryColorByPaletteId(paletteId: Int): CategoryColor { //
+            return values().find { it.paletteId == paletteId } ?: SCHEDULE // 못 찾으면 기본 색상으로
+        }
+
+        // paletteId로 hexColor를 반환
+        fun convertPaletteIdToHexColor(paletteId: Int): String {
+            return findCategoryColorByPaletteId(paletteId).hexColor
+        }
+
+        // 카테고리 색상뷰 배경색 바꾸기 용도
+        fun convertPaletteIdToColorStateList(paletteId: Int) : ColorStateList {
+            return ColorStateList.valueOf(convertHexToInt(convertPaletteIdToHexColor(paletteId)))
+        }
+
+
+        private fun convertHexToInt(hexColor: String): Int {
+            return Color.parseColor(hexColor)
         }
     }
 }

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/MainActivity.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/MainActivity.kt
@@ -83,7 +83,7 @@ class MainActivity : AppCompatActivity(), ScheduleView, DeleteScheduleView, GetA
     private val serverCategory = ArrayList<Category>()
     private val serverDiary = ArrayList<Diary>()
 
-    private lateinit var categoryColorArray: IntArray
+//    private lateinit var categoryColorArray: IntArray
 
     private var isCategorySuccess = false
     private var isScheduleSuccess = false
@@ -124,8 +124,8 @@ class MainActivity : AppCompatActivity(), ScheduleView, DeleteScheduleView, GetA
         binding = DataBindingUtil.setContentView(this, R.layout.activity_main)
         db = NamoDatabase.getInstance(this)
         initNavigation()
-        categoryColorArray =resources.getIntArray(R.array.categoryColorArr)
-        Log.d("CATEGORY_ARR", categoryColorArray.contentToString())
+//        categoryColorArray =resources.getIntArray(R.array.categoryColorArr)
+//        Log.d("CATEGORY_ARR", categoryColorArray.contentToString())
 
 //        logToken()
         checkPermissions()
@@ -245,23 +245,18 @@ class MainActivity : AppCompatActivity(), ScheduleView, DeleteScheduleView, GetA
                 }
             }
         }
-        val paletteDatas = arrayListOf(
-            categoryColorArray[4], categoryColorArray[5], categoryColorArray[6], categoryColorArray[7], categoryColorArray[8],
-            categoryColorArray[9], categoryColorArray[10], categoryColorArray[11], categoryColorArray[12], categoryColorArray[13]
-        )
+//        val paletteDatas = arrayListOf(
+//            categoryColorArray[4], categoryColorArray[5], categoryColorArray[6], categoryColorArray[7], categoryColorArray[8],
+//            categoryColorArray[9], categoryColorArray[10], categoryColorArray[11], categoryColorArray[12], categoryColorArray[13]
+//        )
 
         for (i in unUploadedCategory) {
-            for (j: Int in paletteDatas.indices) {
-                if (paletteDatas[j] == i.color) {
-                    paletteId = j + 5
-                }
-            }
             if (i.serverId == 0L) {
                 if (i.state == RoomState.DELETED.state) {
                     return
                 } else {
                     //POST
-                    CategoryService(this).tryPostCategory(CategoryBody(i.name, paletteId, i.share), i.categoryId)
+                    CategoryService(this).tryPostCategory(CategoryBody(i.name, i.paletteId, i.share), i.categoryId)
                 }
             } else {
                 if (i.state == RoomState.DELETED.state) {
@@ -605,14 +600,14 @@ class MainActivity : AppCompatActivity(), ScheduleView, DeleteScheduleView, GetA
     }
 
     private fun serverToCategory(category: GetCategoryResult): Category {
-        Log.d(
-            "CATEGORY_ARR",
-            "Server to Category - color : ${categoryColorArray[category.paletteId - 1]}"
-        )
+//        Log.d(
+//            "CATEGORY_ARR",
+//            "Server to Category - color : ${category}"
+//        )
         return Category(
             0,
             category.name,
-            categoryColorArray[category.paletteId - 1],
+            category.paletteId, //categoryColorArray[category.paletteId - 1],
             category.isShare,
             true,
             IS_UPLOAD,

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/bottom/custom/CustomMyFragment.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/bottom/custom/CustomMyFragment.kt
@@ -6,15 +6,15 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.LinearLayoutManager
-import com.mongmong.namo.R
 import com.mongmong.namo.data.local.entity.custom.Palette
 import com.mongmong.namo.databinding.FragmentCustomMyBinding
+import com.mongmong.namo.presentation.config.CategoryColor
+import com.mongmong.namo.presentation.config.PaletteType
 import com.mongmong.namo.presentation.ui.bottom.custom.adapter.PaletteRVAdapter
 
 class CustomMyFragment : Fragment() {
 
     lateinit var binding : FragmentCustomMyBinding
-    lateinit var palette1ColorArr : IntArray
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -22,11 +22,9 @@ class CustomMyFragment : Fragment() {
     ): View? {
         binding = FragmentCustomMyBinding.inflate(inflater, container, false)
 
-        palette1ColorArr = resources.getIntArray(R.array.palette1ColorArr)
-
         // 팔레트 페이지랑 동일한 데이터
         val paletteDatas = arrayListOf(
-            Palette("기본 팔레트", palette1ColorArr)
+            Palette("기본 팔레트", CategoryColor.findColorsByPaletteType(PaletteType.BASIC_PALETTE))
         )
 
         //어댑터 연결

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/bottom/custom/CustomPaletteFragment.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/bottom/custom/CustomPaletteFragment.kt
@@ -6,16 +6,15 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.LinearLayoutManager
-import com.mongmong.namo.R
 import com.mongmong.namo.data.local.entity.custom.Palette
 import com.mongmong.namo.presentation.ui.bottom.custom.adapter.PaletteRVAdapter
 import com.mongmong.namo.databinding.FragmentCustomPaletteBinding
+import com.mongmong.namo.presentation.config.CategoryColor
+import com.mongmong.namo.presentation.config.PaletteType
 
 class CustomPaletteFragment : Fragment() {
 
     lateinit var binding : FragmentCustomPaletteBinding
-    lateinit var palette1ColorArr : IntArray
-//    private var paletteDatas = ArrayList<Palette>()
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -25,11 +24,9 @@ class CustomPaletteFragment : Fragment() {
     ): View? {
         binding = FragmentCustomPaletteBinding.inflate(inflater, container, false)
 
-        palette1ColorArr = resources.getIntArray(R.array.palette1ColorArr)
-
         // 팔레트 색 Arr 넣어주기
         val paletteDatas = arrayListOf(
-            Palette("기본 팔레트", palette1ColorArr)
+            Palette("기본 팔레트", CategoryColor.findColorsByPaletteType(PaletteType.BASIC_PALETTE))
         )
 
         //어댑터 연결

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/bottom/custom/adapter/PaletteColorRVAdapter.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/bottom/custom/adapter/PaletteColorRVAdapter.kt
@@ -1,12 +1,14 @@
 package com.mongmong.namo.presentation.ui.bottom.custom.adapter
 
 import android.content.Context
+import android.content.res.ColorStateList
+import android.graphics.Color
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.mongmong.namo.databinding.ItemPaletteColorBinding
 
-class PaletteColorRVAdapter(val context: Context, private val colors: IntArray) : RecyclerView.Adapter<PaletteColorRVAdapter.ViewHolder>() {
+class PaletteColorRVAdapter(val context: Context, private val colors: ArrayList<String>) : RecyclerView.Adapter<PaletteColorRVAdapter.ViewHolder>() {
 
     override fun onCreateViewHolder(viewGroup: ViewGroup, viewType: Int): ViewHolder {
         val binding: ItemPaletteColorBinding = ItemPaletteColorBinding.inflate(
@@ -23,8 +25,8 @@ class PaletteColorRVAdapter(val context: Context, private val colors: IntArray) 
 
     inner class ViewHolder(val binding: ItemPaletteColorBinding): RecyclerView.ViewHolder(binding.root) {
 
-        fun bind(color : Int) {
-            binding.itemPaletteColorCv.background.setTint(color)
+        fun bind(hexColor : String) {
+            binding.itemPaletteColorCv.backgroundTintList = ColorStateList.valueOf(Color.parseColor(hexColor))
         }
     }
 }

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/bottom/diary/DiaryAdapter.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/bottom/diary/DiaryAdapter.kt
@@ -14,6 +14,7 @@ import com.mongmong.namo.domain.model.DiarySchedule
 import com.mongmong.namo.data.remote.diary.DiaryRepository
 import com.mongmong.namo.databinding.ItemDiaryItemListBinding
 import com.mongmong.namo.databinding.ItemDiaryListBinding
+import com.mongmong.namo.presentation.config.CategoryColor
 
 import com.mongmong.namo.presentation.ui.bottom.diary.personalDiary.adapter.DiaryGalleryRVAdapter
 import java.text.SimpleDateFormat
@@ -112,9 +113,7 @@ class DiaryAdapter( // 월 별 개인 다이어리 리스트 어댑터
                 val category =
                     repo.getCategory(item.categoryId, item.categoryServerId)
 
-                context.resources?.let {
-                    itemDiaryCategoryColorIv.background.setTint(category.color)
-                }
+                itemDiaryCategoryColorIv.backgroundTintList = CategoryColor.convertPaletteIdToColorStateList(category.paletteId)
 
                 val adapter =
                     DiaryGalleryRVAdapter(context, item.images, imageClickListener)

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/bottom/diary/DiaryGroupAdapter.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/bottom/diary/DiaryGroupAdapter.kt
@@ -14,6 +14,7 @@ import com.mongmong.namo.domain.model.DiarySchedule
 import com.mongmong.namo.data.remote.diary.DiaryRepository
 import com.mongmong.namo.databinding.ItemDiaryItemListBinding
 import com.mongmong.namo.databinding.ItemDiaryListBinding
+import com.mongmong.namo.presentation.config.CategoryColor
 import com.mongmong.namo.presentation.ui.bottom.diary.personalDiary.adapter.DiaryGalleryRVAdapter
 import java.text.SimpleDateFormat
 
@@ -107,9 +108,7 @@ class DiaryGroupAdapter(  // 월 별 그룹 다이어리 리스트 어댑터
                 val category =
                     repo.getCategory(item.categoryId, item.categoryId)
 
-                context.resources?.let {
-                    binding.itemDiaryCategoryColorIv.background.setTint(category.color)
-                }
+                binding.itemDiaryCategoryColorIv.backgroundTintList = CategoryColor.convertPaletteIdToColorStateList(category.paletteId)
 
                 val adapter =
                     DiaryGalleryRVAdapter(context, item.images, imageClickListener)

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/bottom/diary/moimDiary/MoimMemoDetailActivity.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/bottom/diary/moimDiary/MoimMemoDetailActivity.kt
@@ -16,6 +16,7 @@ import com.mongmong.namo.data.remote.diary.*
 import com.mongmong.namo.databinding.ActivityMoimMemoDetailBinding
 import com.mongmong.namo.domain.model.DiaryResponse
 import com.mongmong.namo.domain.model.MoimDiary
+import com.mongmong.namo.presentation.config.CategoryColor
 import com.mongmong.namo.presentation.ui.bottom.diary.personalDiary.adapter.GalleryListAdapter
 import com.mongmong.namo.presentation.utils.ConfirmDialog
 import com.mongmong.namo.presentation.utils.ConfirmDialogInterface
@@ -70,7 +71,7 @@ class MoimMemoDetailActivity: AppCompatActivity(),
         with(binding) {
             val repo = DiaryRepository(this@MoimMemoDetailActivity)
             val category = repo.getCategory(moimSchedule.categoryId, moimSchedule.categoryId)
-            itemDiaryCategoryColorIv.background.setTint(category.color)
+            itemDiaryCategoryColorIv.backgroundTintList = CategoryColor.convertPaletteIdToColorStateList(category.paletteId)
             val scheduleDate = moimSchedule.startDate * 1000
 
             diaryTodayMonthTv.text = DateTime(scheduleDate).toString("MMM", Locale.ENGLISH)

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/bottom/diary/personalDiary/PersonalDetailActivity.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/bottom/diary/personalDiary/PersonalDetailActivity.kt
@@ -4,6 +4,8 @@ import android.Manifest
 import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Intent
+import android.content.res.ColorStateList
+import android.graphics.Color
 import android.graphics.Rect
 import android.os.Build
 import android.os.Bundle
@@ -30,6 +32,7 @@ import com.mongmong.namo.presentation.ui.bottom.diary.personalDiary.adapter.Gall
 import com.mongmong.namo.presentation.utils.ConfirmDialog
 import com.mongmong.namo.presentation.utils.ConfirmDialogInterface
 import com.google.android.material.snackbar.Snackbar
+import com.mongmong.namo.presentation.config.CategoryColor
 import com.mongmong.namo.presentation.utils.ImageConverter.imageToFile
 import com.mongmong.namo.presentation.utils.PermissionChecker
 import com.mongmong.namo.presentation.utils.PermissionChecker.hasImagePermission
@@ -71,7 +74,7 @@ class PersonalDetailActivity : AppCompatActivity(), ConfirmDialogInterface {  //
         hasDiary()
 
         val category = repo.getCategory(schedule.categoryId, schedule.categoryServerId)
-        binding.itemDiaryCategoryColorIv.background.setTint(category.color)
+        binding.itemDiaryCategoryColorIv.backgroundTintList = ColorStateList.valueOf(Color.parseColor(CategoryColor.convertPaletteIdToHexColor(category.paletteId)))
 
         binding.apply {
             val formatDate = DateTime(schedule.startLong * 1000).toString("yyyy.MM.dd (EE)")

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/bottom/group/adapter/GroupInfoMemberRVAdapter.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/bottom/group/adapter/GroupInfoMemberRVAdapter.kt
@@ -1,6 +1,8 @@
 package com.mongmong.namo.presentation.ui.bottom.group.adapter
 
 import android.content.Context
+import android.content.res.ColorStateList
+import android.graphics.Color
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.ViewGroup
@@ -8,13 +10,15 @@ import androidx.recyclerview.widget.RecyclerView
 import com.mongmong.namo.R
 import com.mongmong.namo.domain.model.MoimUser
 import com.mongmong.namo.databinding.ItemGroupMemberBinding
+import com.mongmong.namo.presentation.config.CategoryColor
+import com.mongmong.namo.presentation.config.PaletteType
 
 class GroupInfoMemberRVAdapter(
     private val members : List<MoimUser>
 ) : RecyclerView.Adapter<GroupInfoMemberRVAdapter.ViewHolder>() {
 
     private lateinit var context : Context
-    private lateinit var categoryColorArray : IntArray
+    private lateinit var categoryColorArray : ArrayList<String>
 
     override fun onCreateViewHolder(
         parent: ViewGroup,
@@ -22,7 +26,7 @@ class GroupInfoMemberRVAdapter(
     ): GroupInfoMemberRVAdapter.ViewHolder {
         val binding = ItemGroupMemberBinding.inflate(LayoutInflater.from(parent.context), parent, false)
         context = parent.context
-        categoryColorArray = context.resources.getIntArray(R.array.categoryColorArr)
+        categoryColorArray = CategoryColor.getAllColors()
 
         return ViewHolder(binding)
     }
@@ -37,9 +41,9 @@ class GroupInfoMemberRVAdapter(
     inner class ViewHolder(val binding : ItemGroupMemberBinding) : RecyclerView.ViewHolder(binding.root) {
         fun bind(member : MoimUser) {
             val color = if (member.color < 20) categoryColorArray[member.color - 1]
-                        else context.resources.getColor(member.color)
+                        else CategoryColor.DEFAULT_PALETTE_COLOR1.hexColor
 
-            binding.itemGroupMemberColorView.background.setTint(color)
+            binding.itemGroupMemberColorView.backgroundTintList = ColorStateList.valueOf(Color.parseColor(color))
             binding.itemGroupMemberNameTv.text = member.userName
         }
     }

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/bottom/group/calendar/GroupCustomCalendarView.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/bottom/group/calendar/GroupCustomCalendarView.kt
@@ -11,6 +11,8 @@ import androidx.core.content.withStyledAttributes
 import com.mongmong.namo.R
 import com.mongmong.namo.data.local.entity.home.Category
 import com.mongmong.namo.domain.model.MoimSchedule
+import com.mongmong.namo.presentation.config.CategoryColor
+import com.mongmong.namo.presentation.config.PaletteType
 import com.mongmong.namo.presentation.ui.bottom.home.calendar.data.StartEnd
 import com.mongmong.namo.presentation.utils.CalendarUtils.Companion.DAYS_PER_WEEK
 import com.mongmong.namo.presentation.utils.CalendarUtils.Companion.WEEKS_PER_MONTH
@@ -75,8 +77,6 @@ class GroupCustomCalendarView(context: Context, attrs : AttributeSet) : View(con
     private var _eventHorizontalPadding: Float = 0f
     private var _eventCornerRadius : Float = 0f
     private var _eventLineHeight : Float = 0f
-
-    private val colorArray = resources.getIntArray(R.array.categoryColorArr)
 
     init {
         context.withStyledAttributes(attrs, R.styleable.CalendarView, defStyleAttr = R.attr.itemViewStyle, defStyleRes = R.style.Calendar_ItemViewStyle) {
@@ -467,7 +467,7 @@ class GroupCustomCalendarView(context: Context, attrs : AttributeSet) : View(con
 //                        }
                         else event.users[0].color
     //    Log.d("GroupCalView", "유저 : ${event.users} | paletteId : ${paletteId}")
-        bgPaint.color = colorArray[paletteId - 1]
+        bgPaint.color = Color.parseColor(CategoryColor.getAllColors()[paletteId - 1])
     }
 
     private fun getScheduleTextStart(title : String, startIdx : Int, endIdx : Int) : Float {

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/bottom/group/calendar/adapter/GroupDailyGroupRVAdapter.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/bottom/group/calendar/adapter/GroupDailyGroupRVAdapter.kt
@@ -2,6 +2,7 @@ package com.mongmong.namo.presentation.ui.bottom.group.calendar.adapter
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.graphics.Color
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.core.content.ContextCompat
@@ -9,12 +10,14 @@ import androidx.recyclerview.widget.RecyclerView
 import com.mongmong.namo.R
 import com.mongmong.namo.domain.model.MoimSchedule
 import com.mongmong.namo.databinding.ItemSchedulePreviewBinding
+import com.mongmong.namo.presentation.config.CategoryColor
+import com.mongmong.namo.presentation.config.PaletteType
 import org.joda.time.DateTime
 
 class GroupDailyGroupRVAdapter() : RecyclerView.Adapter<GroupDailyGroupRVAdapter.ViewHolder>() {
 
     private val groupSchedule = ArrayList<MoimSchedule>()
-    lateinit var colorArray: IntArray
+    lateinit var colorArray: ArrayList<String>
     private lateinit var context : Context
 
     interface DiaryInterface {
@@ -39,7 +42,7 @@ class GroupDailyGroupRVAdapter() : RecyclerView.Adapter<GroupDailyGroupRVAdapter
         val binding : ItemSchedulePreviewBinding = ItemSchedulePreviewBinding.inflate(
             LayoutInflater.from(viewGroup.context), viewGroup, false)
         context = viewGroup.context
-        colorArray = context.resources.getIntArray(R.array.categoryColorArr)
+        colorArray = CategoryColor.getAllColors()
 
         return ViewHolder(binding)
     }
@@ -80,7 +83,7 @@ class GroupDailyGroupRVAdapter() : RecyclerView.Adapter<GroupDailyGroupRVAdapter
             binding.itemCalendarTitle.text = groupSchedule.name
             binding.itemCalendarTitle.isSelected = true
             binding.itemCalendarTitle.text = time
-            binding.itemCalendarEventColorView.background.setTint(colorArray[paletteId - 1])
+            binding.itemCalendarEventColorView.background.setTint(Color.parseColor(colorArray[paletteId - 1]))
 
             if(groupSchedule.hasDiaryPlace)
                 binding.itemCalendarEventRecord.setColorFilter(ContextCompat.getColor(context,R.color.MainOrange))

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/bottom/group/calendar/adapter/GroupDailyPersonalRVAdapter.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/bottom/group/calendar/adapter/GroupDailyPersonalRVAdapter.kt
@@ -2,25 +2,26 @@ package com.mongmong.namo.presentation.ui.bottom.group.calendar.adapter
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.graphics.Color
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.mongmong.namo.R
 import com.mongmong.namo.domain.model.MoimSchedule
 import com.mongmong.namo.databinding.ItemSchedulePreviewMoimBinding
+import com.mongmong.namo.presentation.config.CategoryColor
+import com.mongmong.namo.presentation.config.PaletteType
 import org.joda.time.DateTime
 
 class GroupDailyPersonalRVAdapter() : RecyclerView.Adapter<GroupDailyPersonalRVAdapter.ViewHolder>() {
 
     private val personal = ArrayList<MoimSchedule>()
-    lateinit var colorArray: IntArray
     private lateinit var context : Context
 
     override fun onCreateViewHolder(viewGroup: ViewGroup, viewType : Int) : ViewHolder {
         val binding : ItemSchedulePreviewMoimBinding = ItemSchedulePreviewMoimBinding.inflate(
             LayoutInflater.from(viewGroup.context), viewGroup, false)
         context = viewGroup.context
-        colorArray = context.resources.getIntArray(R.array.categoryColorArr)
 
         return ViewHolder(binding)
     }
@@ -42,6 +43,8 @@ class GroupDailyPersonalRVAdapter() : RecyclerView.Adapter<GroupDailyPersonalRVA
 
         @SuppressLint("ResourceType")
         fun bind(personal: MoimSchedule) {
+            val colorArray = CategoryColor.getAllColors()
+
             val time =
                 DateTime(personal.startDate * 1000L).toString("HH:mm") + " - " + DateTime(personal.endDate * 1000L).toString(
                     "HH:mm"
@@ -59,7 +62,7 @@ class GroupDailyPersonalRVAdapter() : RecyclerView.Adapter<GroupDailyPersonalRVA
             binding.itemCalendarTitle.text = personal.name
             binding.itemCalendarTitle.isSelected = true
             binding.itemCalendarEventTime.text = time
-            binding.itemCalendarEventColorView.background.setTint(colorArray[paletteId - 1])
+            binding.itemCalendarEventColorView.background.setTint(Color.parseColor(colorArray[paletteId - 1]))
             binding.itemCalendarUserName.text = userName
         }
     }

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/bottom/home/adapter/DailyGroupRVAdapter.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/bottom/home/adapter/DailyGroupRVAdapter.kt
@@ -12,6 +12,7 @@ import com.mongmong.namo.data.local.entity.home.Category
 import com.mongmong.namo.data.local.entity.home.Schedule
 import com.mongmong.namo.databinding.ItemSchedulePreviewBinding
 import com.mongmong.namo.domain.model.MoimDiary
+import com.mongmong.namo.presentation.config.CategoryColor
 import org.joda.time.DateTime
 
 class DailyGroupRVAdapter : RecyclerView.Adapter<DailyGroupRVAdapter.ViewHolder>() {
@@ -99,7 +100,7 @@ class DailyGroupRVAdapter : RecyclerView.Adapter<DailyGroupRVAdapter.ViewHolder>
             binding.itemCalendarTitle.isSelected = true
             binding.itemCalendarEventTime.text = time
             if (category != null) {
-                binding.itemCalendarEventColorView.background.setTint(category.color)
+                binding.itemCalendarEventColorView.backgroundTintList = CategoryColor.convertPaletteIdToColorStateList(category.paletteId)
             }
             binding.itemCalendarEventRecord.setColorFilter(ContextCompat.getColor(context,R.color.realGray))
 

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/bottom/home/adapter/DailyPersonalRVAdapter.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/bottom/home/adapter/DailyPersonalRVAdapter.kt
@@ -10,6 +10,7 @@ import com.mongmong.namo.data.local.entity.home.Schedule
 import com.mongmong.namo.R
 import com.mongmong.namo.data.local.entity.home.Category
 import com.mongmong.namo.databinding.ItemSchedulePreviewBinding
+import com.mongmong.namo.presentation.config.CategoryColor
 import org.joda.time.DateTime
 
 class DailyPersonalRVAdapter() : RecyclerView.Adapter<DailyPersonalRVAdapter.ViewHolder>() {
@@ -84,7 +85,7 @@ class DailyPersonalRVAdapter() : RecyclerView.Adapter<DailyPersonalRVAdapter.Vie
             binding.itemCalendarTitle.text = personal.title
             binding.itemCalendarTitle.isSelected = true
             binding.itemCalendarEventTime.text = time
-            binding.itemCalendarEventColorView.background.setTint(category.color)
+            binding.itemCalendarEventColorView.backgroundTintList = CategoryColor.convertPaletteIdToColorStateList(category.paletteId)
             binding.itemCalendarEventRecord.setColorFilter(ContextCompat.getColor(context,R.color.realGray))
 
             /** 기록 아이콘 색깔 **/

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/bottom/home/calendar/CustomCalendarView.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/bottom/home/calendar/CustomCalendarView.kt
@@ -12,6 +12,7 @@ import androidx.core.content.withStyledAttributes
 import com.mongmong.namo.R
 import com.mongmong.namo.data.local.entity.home.Category
 import com.mongmong.namo.data.local.entity.home.Schedule
+import com.mongmong.namo.presentation.config.CategoryColor
 import com.mongmong.namo.presentation.ui.bottom.home.calendar.data.StartEnd
 import com.mongmong.namo.presentation.utils.CalendarUtils.Companion.DAYS_PER_WEEK
 import com.mongmong.namo.presentation.utils.CalendarUtils.Companion.WEEKS_PER_MONTH
@@ -461,13 +462,12 @@ class CustomCalendarView(context: Context, attrs : AttributeSet) : View(context,
 //        Log.d("BG_COLOR_CHECK", categoryList.toString())
 //        Log.d("BG_COLOR_CHECK", event.toString())
 //        Log.d("BG_COLOR_CHECK", "Category Server : " + event.categoryServerId + " | Category Idx : " + event.categoryId)
-
         val foundCategory = categoryList.find {
             if (it.serverId != 0L) it.serverId == event.categoryServerId
             else it.categoryId == event.categoryId
         }
-
-        bgPaint.color = foundCategory?.color ?: R.color.schedule
+        val hexColor = CategoryColor.convertPaletteIdToHexColor(foundCategory?.paletteId ?: 0)
+        bgPaint.color = Color.parseColor(hexColor)
     }
 
     private fun getScheduleTextStart(title : String, startIdx : Int, endIdx : Int) : Float {

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/bottom/home/category/CategoryDetailFragment.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/bottom/home/category/CategoryDetailFragment.kt
@@ -210,7 +210,7 @@ class CategoryDetailFragment(private val isEditMode: Boolean) : Fragment(), Cate
     private fun initPaletteColorRv(initCategory: CategoryColor) {
 
         // 기본 팔레트
-        val paletteDatas = CategoryColor.findPalettes(PaletteType.BASIC_PALETTE)
+        val paletteDatas = CategoryColor.findPaletteByPaletteType(PaletteType.BASIC_PALETTE)
 
         for (i: Int in paletteDatas.indices) {
             if (paletteDatas[i] == color) {
@@ -260,7 +260,7 @@ class CategoryDetailFragment(private val isEditMode: Boolean) : Fragment(), Cate
                 }
                 // 선택한 카테고리 표시
                 checkList[i].visibility = View.VISIBLE
-                color = CategoryColor.findPalettes(PaletteType.DEFAULT_4)[i]
+                color = CategoryColor.findPaletteByPaletteType(PaletteType.DEFAULT_4)[i]
                 paletteId = color!!.paletteId
                 // 이제 팔레트가 아니라 기본 색상에서 설정한 색임
                 selectedPalettePosition = null
@@ -300,7 +300,7 @@ class CategoryDetailFragment(private val isEditMode: Boolean) : Fragment(), Cate
                     categoryDetailTitleEt.setText(data.name)
                     // 카테고리 색
                     color = CategoryColor.findCategoryColorByPaletteId(data.paletteId)
-                    if (CategoryColor.findPalettes(PaletteType.DEFAULT_4).contains(color)) {
+                    if (CategoryColor.findPaletteByPaletteType(PaletteType.DEFAULT_4).contains(color)) {
                         // 기본 카테고리 체크 표시
                         checkList[color!!.paletteId - 1].visibility = View.VISIBLE
                         paletteId = color!!.paletteId

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/bottom/home/category/CategoryDetailFragment.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/bottom/home/category/CategoryDetailFragment.kt
@@ -26,7 +26,7 @@ import com.mongmong.namo.presentation.utils.NetworkManager
 import com.google.gson.Gson
 import com.google.gson.JsonParseException
 import com.google.gson.reflect.TypeToken
-import com.mongmong.namo.presentation.config.BelongType
+import com.mongmong.namo.presentation.config.PaletteType
 import com.mongmong.namo.presentation.config.CategoryColor
 import com.mongmong.namo.presentation.config.RoomState
 
@@ -210,7 +210,7 @@ class CategoryDetailFragment(private val isEditMode: Boolean) : Fragment(), Cate
     private fun initPaletteColorRv(initCategory: CategoryColor) {
 
         // 기본 팔레트
-        val paletteDatas = CategoryColor.findPalettes(BelongType.BELONG2)
+        val paletteDatas = CategoryColor.findPalettes(PaletteType.BASIC_PALETTE)
 
         for (i: Int in paletteDatas.indices) {
             if (paletteDatas[i] == color) {
@@ -260,7 +260,7 @@ class CategoryDetailFragment(private val isEditMode: Boolean) : Fragment(), Cate
                 }
                 // 선택한 카테고리 표시
                 checkList[i].visibility = View.VISIBLE
-                color = CategoryColor.findPalettes(BelongType.BELONG1)[i]
+                color = CategoryColor.findPalettes(PaletteType.DEFAULT_4)[i]
                 paletteId = color!!.paletteId
                 // 이제 팔레트가 아니라 기본 색상에서 설정한 색임
                 selectedPalettePosition = null
@@ -300,7 +300,7 @@ class CategoryDetailFragment(private val isEditMode: Boolean) : Fragment(), Cate
                     categoryDetailTitleEt.setText(data.name)
                     // 카테고리 색
                     color = CategoryColor.findCategoryColorByPaletteId(data.paletteId)
-                    if (CategoryColor.findPalettes(BelongType.BELONG1).contains(color)) {
+                    if (CategoryColor.findPalettes(PaletteType.DEFAULT_4).contains(color)) {
                         // 기본 카테고리 체크 표시
                         checkList[color!!.paletteId - 1].visibility = View.VISIBLE
                         paletteId = color!!.paletteId

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/bottom/home/category/adapter/CategoryPaletteRVAdapter.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/bottom/home/category/adapter/CategoryPaletteRVAdapter.kt
@@ -1,22 +1,24 @@
 package com.mongmong.namo.presentation.ui.bottom.home.category.adapter
 
 import android.content.Context
+import android.graphics.Color
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.mongmong.namo.databinding.ItemPaletteColorBinding
+import com.mongmong.namo.presentation.config.CategoryColor
 
 class CategoryPaletteRVAdapter(
     val context: Context,
-    private val colorList: ArrayList<Int>,
-    initColor: Int,
+    private val colorList: ArrayList<CategoryColor>,
+    initColor: CategoryColor,
     selectedPalettePosition: Int
     ): RecyclerView.Adapter<CategoryPaletteRVAdapter.ViewHolder>() {
 
     interface MyItemClickListener {
-        fun onItemClick(position: Int, selectedColor: Int)
+        fun onItemClick(position: Int, selectedColor: CategoryColor)
     }
 
     private lateinit var mItemClickListener: MyItemClickListener
@@ -64,11 +66,11 @@ class CategoryPaletteRVAdapter(
     inner class ViewHolder(val binding: ItemPaletteColorBinding): RecyclerView.ViewHolder(binding.root) {
         val selectIv = binding.itemPaletteSelectIv
 
-        fun bind(color : Int) {
+        fun bind(color : CategoryColor) {
             // 카테고리 색 확인
 //            Log.d("PaletteColor", "position = ${absoluteAdapterPosition} color = $color")
             // 카드뷰에 색 넣어주기
-            binding.itemPaletteColorCv.background.setTint(color)
+            binding.itemPaletteColorCv.backgroundTintList = CategoryColor.convertPaletteIdToColorStateList(color.paletteId)
             // 체크 표시 초기화
             if (adapterPosition == currentSelectPosition) selectIv.visibility = View.VISIBLE
             else selectIv.visibility = View.GONE

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/bottom/home/category/adapter/SetCategoryRVAdapter.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/bottom/home/category/adapter/SetCategoryRVAdapter.kt
@@ -1,11 +1,13 @@
 package com.mongmong.namo.presentation.ui.bottom.home.category.adapter
 
 import android.content.Context
+import android.graphics.Color
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.mongmong.namo.databinding.ItemCategoryBinding
 import com.mongmong.namo.data.local.entity.home.Category
+import com.mongmong.namo.presentation.config.CategoryColor
 
 class SetCategoryRVAdapter(
     val context: Context,
@@ -43,7 +45,7 @@ class SetCategoryRVAdapter(
     inner class ViewHolder(val binding: ItemCategoryBinding): RecyclerView.ViewHolder(binding.root) {
 
         fun bind(category : Category) {
-            binding.itemCategoryColorIv.background.setTint(category.color)
+            binding.itemCategoryColorIv.background.setTint(Color.parseColor(CategoryColor.convertPaletteIdToHexColor(category.paletteId)))
             binding.itemCategoryNameTv.text = category.name
         }
 

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/bottom/home/schedule/ScheduleDialogBasicFragment.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/bottom/home/schedule/ScheduleDialogBasicFragment.kt
@@ -50,6 +50,7 @@ import com.mongmong.namo.presentation.ui.bottom.home.notify.PushNotificationRece
 import com.mongmong.namo.presentation.ui.bottom.home.schedule.map.MapActivity
 import com.mongmong.namo.presentation.utils.CalendarUtils.Companion.getInterval
 import com.google.android.material.chip.Chip
+import com.mongmong.namo.presentation.config.CategoryColor
 import com.mongmong.namo.presentation.config.RoomState
 import com.mongmong.namo.presentation.config.UploadState
 import dagger.hilt.android.AndroidEntryPoint
@@ -818,7 +819,7 @@ class ScheduleDialogBasicFragment : Fragment(), EditMoimScheduleView {
     private fun setCategory() {
         event.categoryServerId = selectedCategory.serverId
         binding.dialogScheduleCategoryNameTv.text = selectedCategory.name
-        binding.dialogScheduleCategoryColorIv.background.setTint(selectedCategory.color)
+        binding.dialogScheduleCategoryColorIv.backgroundTintList = CategoryColor.convertPaletteIdToColorStateList(selectedCategory.paletteId)
     }
 
     private fun printNotUploaded() {

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/bottom/home/schedule/adapter/DialogCategoryRVAdapter.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/bottom/home/schedule/adapter/DialogCategoryRVAdapter.kt
@@ -7,6 +7,7 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.mongmong.namo.data.local.entity.home.Category
 import com.mongmong.namo.databinding.ItemDialogScheduleCategoryBinding
+import com.mongmong.namo.presentation.config.CategoryColor
 
 class DialogCategoryRVAdapter(
     var context: Context,
@@ -27,7 +28,7 @@ class DialogCategoryRVAdapter(
 
     inner class ViewHolder(val binding : ItemDialogScheduleCategoryBinding) : RecyclerView.ViewHolder(binding.root) {
         fun bind(category : Category) {
-            binding.categoryColorView.background.setTint(category.color)
+            binding.categoryColorView.backgroundTintList = CategoryColor.convertPaletteIdToColorStateList(category.paletteId)
             binding.categoryNameTv.text = category.name
 
             if (category.categoryId == selectedIdx) {

--- a/app/src/main/res/drawable/bg_diary_preview_category_color_corner.xml
+++ b/app/src/main/res/drawable/bg_diary_preview_category_color_corner.xml
@@ -6,8 +6,8 @@
         android:topLeftRadius="20dp"/>
     <stroke
         android:width="1dp"
-        android:color="@color/todo_assignment"/>
+        android:color="@color/schedule"/>
     <solid
-        android:color="@color/todo_assignment"/>
+        android:color="@color/schedule"/>
 
 </shape>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -25,14 +25,7 @@
     <color name="schedule">#DE8989</color> //일정
     <color name="schedule_plan">#E1B000</color> //약속
     <color name="schedule_parttime">#5C8596</color> //알바
-    <color name="schedule_special">#AD7FFF</color> //기념일
     <color name="schedule_group">#DA6022</color> //그룹 일정
-    <color name="test">#29ABE2</color>
-    <!-- Todo Category -->
-    <color name="todo">#DE8989</color>
-    <color name="todo_assignment">#89C5DE</color>
-    <color name="todo_housework">#64D49F</color>
-    <color name="todo_study">#C9C9C9</color>
 
     <!-- Nomal Palette -->
     <color name="palette1">#EB5353</color>
@@ -45,35 +38,4 @@
     <color name="palette8">#8571BF</color>
     <color name="palette9">#E36488</color>
     <color name="palette10">#858585</color>
-
-    <!--  Color Array  -->
-    <array name="categoryColorArr">
-        <item>@color/schedule</item>
-        <item>@color/schedule_plan</item>
-        <item>@color/schedule_parttime</item>
-        <item>@color/schedule_group</item>
-        <item>@color/palette1</item>
-        <item>@color/palette2</item>
-        <item>@color/palette3</item>
-        <item>@color/palette4</item>
-        <item>@color/palette5</item>
-        <item>@color/palette6</item>
-        <item>@color/palette7</item>
-        <item>@color/palette8</item>
-        <item>@color/palette9</item>
-        <item>@color/palette10</item>
-    </array>
-
-    <array name="palette1ColorArr">
-        <item>@color/palette1</item>
-        <item>@color/palette2</item>
-        <item>@color/palette3</item>
-        <item>@color/palette4</item>
-        <item>@color/palette5</item>
-        <item>@color/palette6</item>
-        <item>@color/palette7</item>
-        <item>@color/palette8</item>
-        <item>@color/palette9</item>
-        <item>@color/palette10</item>
-    </array>
 </resources>


### PR DESCRIPTION
## Related Issue
- #151 

## Type of change
<!-- 작업의 종류를 선택해주세요. -->
- [x] Refactor : 코드 리팩토링 작업
- [x] Style : 코드 스타일 및 포맷팅 작업

## PR Description
![image](https://github.com/Namo-Mongmong/Android/assets/101113025/e433f710-4b1a-4ccd-b97f-d6f5f42d6846)
- 룸디비 `category_table`에 color 대신 paletteId를 저장하도록 했습니다.
- 앱 내부에 색상을 저장해놓는 CategoryColor 메서드를 만들었습니다.
- 기존에 R.color.white 식으로 저장되어있는 색상을 "#FFFFFF"의 hexColor로 관리하고자 합니다.
- colors.xml에 저장되어있던 categoryColorArr도 삭제했습니다.
- 카테고리를 찾지 못하는 경우 기본 `SCHEDULE` 색상으로 표시되도록 했습니다.


## Requirements for Reviewer
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

- CategoryColor 클래스를 확인해주시면 좋을 것 같습니다.

## PR Log

> PR 작업하면서 고민했던 내용, 해결한 내용, 고민 중인 내용 등

### 새롭게 배운 것

- 뷰에 색상을 tint로 입히는 다양한 방법들

### 고민 중인 사항

- Int 색상과 String 색상 중 어떻게 관리하는 게 성능 상 더 나을지 모르겠어서, 우선 colors.xml에 저장되어있는 Int Color는 그대로 나두었습니다. 
- 다음에 성능 분석을 한번 해보고 변경하면 좋을 거 같아요!

## 첨부 자료

-
