### PR TITLE
[Refactor/179] 캘린더 일정 타이틀 표시 변경

### DIFF
--- a/app/src/main/java/com/mongmong/namo/data/datasource/auth/RemoteAuthDataSource.kt
+++ b/app/src/main/java/com/mongmong/namo/data/datasource/auth/RemoteAuthDataSource.kt
@@ -18,7 +18,8 @@ class RemoteAuthDataSource @Inject constructor(
         var loginResponse = LoginResponse(
             result = LoginResult(
                 accessToken = "",
-                refreshToken = ""
+                refreshToken = "",
+                newUser = false
             )
         )
         withContext(Dispatchers.IO) {
@@ -40,7 +41,8 @@ class RemoteAuthDataSource @Inject constructor(
         var loginResponse = LoginResponse(
             result = LoginResult(
                 accessToken = "",
-                refreshToken = ""
+                refreshToken = "",
+                newUser = false
             )
         )
         withContext(Dispatchers.IO) {

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/group/calendar/GroupCalendarView.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/group/calendar/GroupCalendarView.kt
@@ -61,11 +61,7 @@ class GroupCalendarView(context: Context, attrs: AttributeSet) :
 
                         canvas.drawText(
                             ellipsizedText.toString(),
-                            getScheduleTextStart(
-                                ellipsizedText.toString(),
-                                splitSchedule.startIdx,
-                                splitSchedule.endIdx
-                            ),
+                            getScheduleTextStart(splitSchedule.startIdx),
                             getScheduleTextBottom(
                                 ellipsizedText.toString(),
                                 splitSchedule.startIdx,
@@ -85,11 +81,7 @@ class GroupCalendarView(context: Context, attrs: AttributeSet) :
 
                         canvas.drawText(
                             scheduleList[i].name,
-                            getScheduleTextStart(
-                                scheduleList[i].name,
-                                splitSchedule.startIdx,
-                                splitSchedule.endIdx
-                            ),
+                            getScheduleTextStart(splitSchedule.startIdx),
                             getScheduleTextBottom(
                                 scheduleList[i].name,
                                 splitSchedule.startIdx,

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/home/calendar/PersonalCalendarView.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/home/calendar/PersonalCalendarView.kt
@@ -63,11 +63,7 @@ class PersonalCalendarView(context: Context, attrs: AttributeSet) :
 
                         canvas.drawText(
                             ellipsizedText.toString(),
-                            getScheduleTextStart(
-                                ellipsizedText.toString(),
-                                splitSchedule.startIdx,
-                                splitSchedule.endIdx
-                            ),
+                            getScheduleTextStart(splitSchedule.startIdx),
                             getScheduleTextBottom(
                                 ellipsizedText.toString(),
                                 splitSchedule.startIdx,
@@ -87,11 +83,7 @@ class PersonalCalendarView(context: Context, attrs: AttributeSet) :
 
                         canvas.drawText(
                             scheduleList[i].title,
-                            getScheduleTextStart(
-                                scheduleList[i].title,
-                                splitSchedule.startIdx,
-                                splitSchedule.endIdx
-                            ),
+                            getScheduleTextStart(splitSchedule.startIdx),
                             getScheduleTextBottom(
                                 scheduleList[i].title,
                                 splitSchedule.startIdx,

--- a/app/src/main/java/com/mongmong/namo/presentation/utils/CustomCalendarView.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/utils/CustomCalendarView.kt
@@ -322,9 +322,12 @@ abstract class CustomCalendarView(context: Context, attrs: AttributeSet) : View(
         )
     }
 
-    fun getScheduleTextStart(title: String, startIdx: Int, endIdx: Int): Float {
-        return (((startIdx % DAYS_PER_WEEK) * cellWidth + _eventHorizontalPadding) + ((endIdx % DAYS_PER_WEEK) * cellWidth + cellWidth - _eventHorizontalPadding)) / 2 - eventBounds.width() / 2
+    fun getScheduleTextStart(startIdx: Int): Float {
+        val startX = (startIdx % DAYS_PER_WEEK) * cellWidth + _eventHorizontalPadding
+        val additionalMargin = dpToPx(context, 2f)  // 여기에서 context는 해당 뷰 또는 액티비티의 컨텍스트입니다.
+        return startX + additionalMargin
     }
+
 
     fun getScheduleTextBottom(title: String, startIdx: Int, endIdx: Int, order: Int): Float {
         return (((startIdx / DAYS_PER_WEEK) * cellHeight + eventTop + (_eventBetweenPadding + _eventHeight) * order) + ((endIdx / DAYS_PER_WEEK) * cellHeight + eventTop + (_eventBetweenPadding * order) + (_eventHeight * (order + 1)))) / 2 + eventBounds.height() / 2


### PR DESCRIPTION
- 일정 타이틀 텍스트를 가운데에서 시작부분으로 변경

## Related Issue
- #179 

## Type of change
<!-- 작업의 종류를 선택해주세요. -->
- [ ] Feature : 새로운 기능 추가
- [ ] Bug fix : 버그 수정
- [x] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [ ] Style : 코드 스타일 및 포맷팅 작업
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## PR Desciption
> 변경 사항 설명
- 캘린더 일정 타이틀을 중심부분에서 시작부분으로 변경

## Requirements for Reviewer
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

-

## PR Log

> PR 작업하면서 고민했던 내용, 해결한 내용, 고민 중인 내용 등

### 새롭게 배운 것

- 

### 고민 중인 사항

- 

## 첨부 자료

-
