### PR TITLE
[Refactor/189] 모임 메모/기록 삭제 api 연동

### DIFF
--- a/app/src/main/java/com/mongmong/namo/data/datasource/diary/RemoteDiaryDataSource.kt
+++ b/app/src/main/java/com/mongmong/namo/data/datasource/diary/RemoteDiaryDataSource.kt
@@ -54,7 +54,7 @@ class RemoteDiaryDataSource @Inject constructor(
         withContext(Dispatchers.IO) {
             runCatching {
                 diaryApiService.editDiary(
-                    scheduleId =  diary.scheduleServerId.toString().convertTextRequest(),
+                    scheduleId = diary.scheduleServerId.toString().convertTextRequest(),
                     content = (diary.content ?: "").convertTextRequest(),
                     imgs = imageToMultipart(images, context)
                 )
@@ -125,21 +125,21 @@ class RemoteDiaryDataSource @Inject constructor(
         return isSuccess
     }
 
-    suspend fun deleteMoimMemo(scheduleId: Long): Boolean {
-        var isSuccess = false
+    suspend fun deleteMoimMemo(scheduleId: Long): Boolean =
         withContext(Dispatchers.IO) {
+            var isSuccess = false
             runCatching {
                 diaryApiService.deleteMoimMemo(scheduleId)
             }.onSuccess {
-                Log.d("RemoteDiaryDataSource patchMoimMemo Success", "$it")
+                Log.d("RemoteDiaryDataSource deleteMoimMemo Success", "$it")
                 isSuccess = true
             }.onFailure {
-                Log.d("RemoteDiaryDataSource patchMoimMemo Failure", "$it")
+                Log.d("RemoteDiaryDataSource deleteMoimMemo Failure", "$it")
             }
-        }
 
-        return isSuccess
-    }
+            Log.d("RemoteDiaryDataSource deleteMoimMemo", "$isSuccess")
+            return@withContext isSuccess
+        }
 
     suspend fun addMoimActivity(
         moimScheduleId: Long,
@@ -172,7 +172,6 @@ class RemoteDiaryDataSource @Inject constructor(
         members: List<Long>?,
         images: List<String>?
     ) {
-
         withContext(Dispatchers.IO) {
             runCatching {
                 groupDiaryApiService.editMoimActivity(
@@ -202,19 +201,17 @@ class RemoteDiaryDataSource @Inject constructor(
         }
     }
 
-    suspend fun deleteMoimDiary(moimDiaryId: Long): Boolean {
-        var isSuccess = false
+    suspend fun deleteMoimDiary(moimScheduleId: Long): Boolean =
         withContext(Dispatchers.IO) {
+            var isSuccess = false
             runCatching {
-                groupDiaryApiService.deleteMoimDiary(moimDiaryId)
+                groupDiaryApiService.deleteMoimDiary(moimScheduleId)
             }.onSuccess {
                 Log.d("RemoteDiaryDataSource deleteMoimDiary Success", "$it")
                 isSuccess = true
             }.onFailure {
                 Log.d("RemoteDiaryDataSource deleteMoimDiary Success", "$it")
             }
+            return@withContext isSuccess
         }
-
-        return isSuccess
-    }
 }

--- a/app/src/main/java/com/mongmong/namo/data/remote/DiaryApiService.kt
+++ b/app/src/main/java/com/mongmong/namo/data/remote/DiaryApiService.kt
@@ -63,7 +63,8 @@ interface DiaryApiService {
         @Body text: String?
     ): DiaryResponse
 
-    @PATCH("group/diaries/person/{scheduleId}")
+    // 모임 기록 삭제 (개인)
+    @DELETE("group/diaries/person/{scheduleId}")
     suspend fun deleteMoimMemo(
         @Path("scheduleId") scheduleId: Long,
     ): DiaryResponse

--- a/app/src/main/java/com/mongmong/namo/data/remote/group/GroupDiaryApiService.kt
+++ b/app/src/main/java/com/mongmong/namo/data/remote/group/GroupDiaryApiService.kt
@@ -41,9 +41,9 @@ interface GroupDiaryApiService {
     ): DiaryResponse
 
     // 모임 기록 삭제 (그룹에서 삭제)
-    @DELETE("group/diaries/all/{scheduleId}")
+    @DELETE("group/diaries/all/{moimScheduleId}")
     suspend fun deleteMoimDiary(
-        @Path("scheduleId") scheduleId: Long
+        @Path("moimScheduleId") moimScheduleId: Long
     ): BaseResponse
 
 }

--- a/app/src/main/java/com/mongmong/namo/data/repositoriyImpl/DiaryRepositoryImpl.kt
+++ b/app/src/main/java/com/mongmong/namo/data/repositoriyImpl/DiaryRepositoryImpl.kt
@@ -150,8 +150,8 @@ class DiaryRepositoryImpl @Inject constructor(
     }
 
     /** 모임 기록 삭제 (그룹에서) **/
-    override suspend fun deleteMoimDiary(moimDiaryId: Long): Boolean {
-        return remoteDiaryDataSource.deleteMoimDiary(moimDiaryId)
+    override suspend fun deleteMoimDiary(moimScheduleId: Long): Boolean {
+        return remoteDiaryDataSource.deleteMoimDiary(moimScheduleId)
     }
 
     override suspend fun uploadDiaryToServer() {

--- a/app/src/main/java/com/mongmong/namo/domain/repositories/DiaryRepository.kt
+++ b/app/src/main/java/com/mongmong/namo/domain/repositories/DiaryRepository.kt
@@ -56,5 +56,5 @@ interface DiaryRepository {
 
     suspend fun deleteMoimActivity(activityId: Long)
 
-    suspend fun deleteMoimDiary(scheduleId: Long): Boolean
+    suspend fun deleteMoimDiary(moimScheduleId: Long): Boolean
 }

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/diary/DiaryDetailViewModel.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/diary/DiaryDetailViewModel.kt
@@ -27,11 +27,11 @@ class DiaryDetailViewModel @Inject constructor(
     private val _imgList = MutableLiveData<List<String>>(emptyList())
     val imgList: LiveData<List<String>> = _imgList
 
-    private val _isDeleteComplete = MutableLiveData<Boolean>()
-    val isDeleteComplete: LiveData<Boolean> = _isDeleteComplete
+    private val _deleteDiaryResult = MutableLiveData<Boolean>()
+    val deleteDiaryResult: LiveData<Boolean> = _deleteDiaryResult
 
-    private val _isMemoDeleteComplete = MutableLiveData<Boolean>()
-    val isMemoDeleteComplete: LiveData<Boolean> = _isMemoDeleteComplete
+    private val _deleteMemoResult = MutableLiveData<Boolean>()
+    val deleteMemoResult: LiveData<Boolean> = _deleteMemoResult
 
     private val _getMoimDiaryResult = MutableLiveData<MoimDiaryResult>()
     val getMoimDiaryResult : LiveData<MoimDiaryResult> = _getMoimDiaryResult
@@ -96,7 +96,7 @@ class DiaryDetailViewModel @Inject constructor(
     fun deletePersonalDiary(localId: Long, scheduleServerId: Long) {
         viewModelScope.launch {
             repository.deleteDiary(localId, scheduleServerId)
-            _isDeleteComplete.postValue(true)
+            _deleteDiaryResult.postValue(true)
         }
     }
 
@@ -121,7 +121,7 @@ class DiaryDetailViewModel @Inject constructor(
     fun deleteMoimMemo(scheduleId: Long) {
         viewModelScope.launch {
             Log.d("MoimDiaryViewModel deleteMoimMemo", "$scheduleId")
-            _isMemoDeleteComplete.value = repository.deleteMoimMemo(scheduleId)
+            _deleteMemoResult.value = repository.deleteMoimMemo(scheduleId)
         }
     }
 

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/diary/MoimMemoDetailActivity.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/diary/MoimMemoDetailActivity.kt
@@ -107,8 +107,9 @@ class MoimMemoDetailActivity: AppCompatActivity(),
             groupDiaryDetailLy.setOnClickListener {// 그룹 다이어리 장소 아이템 추가 화면으로 이동
                 startActivity(
                     Intent(this@MoimMemoDetailActivity, MoimDiaryActivity::class.java)
-                        .putExtra("hasGroupPlace", true)
-                        .putExtra("groupScheduleId", moimSchedule.scheduleId)
+                        .putExtra("from", "moimMemo")
+                        .putExtra("hasMoimPlace", true)
+                        .putExtra("moimScheduleId", moimSchedule.scheduleId)
                 )
             }
             diaryEditBtnTv.setOnClickListener {

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/diary/MoimMemoDetailActivity.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/diary/MoimMemoDetailActivity.kt
@@ -116,17 +116,12 @@ class MoimMemoDetailActivity: AppCompatActivity(),
                     moimSchedule.scheduleId,
                     binding.diaryContentsEt.text.toString()
                 )
-                /*diaryService.addGroupAfterDiary(
-                    moimSchedule.scheduleId,
-                    binding.diaryContentsEt.text.toString()
-                )*/
             }
         }
     }
     private fun initObserve() {
         // 모임 기록 가져오기
         viewModel.getMoimDiaryResult.observe(this) { result ->
-            //TODO: 수정 필요
             placeIntList = result.moimActivities.map {
                 it.moimActivityId // 그룹 스케줄 별 장소 아이디 가져와서 리스트 만들기
             }
@@ -146,16 +141,15 @@ class MoimMemoDetailActivity: AppCompatActivity(),
         }
 
         // 모임 기록 메모 삭제
-        viewModel.isDeleteComplete.observe(this) { isComplete ->
+        viewModel.deleteMemoResult.observe(this) { isComplete ->
+            Log.d("isDeleteComplete", "$isComplete")
             if(isComplete) finish()
             else Toast.makeText(this, "네트워크 오류", Toast.LENGTH_SHORT).show()
         }
     }
 
     private fun findCategory(localId: Long, serverId: Long) {
-        lifecycleScope.launch {
-            viewModel.findCategoryById(localId, serverId)
-        }
+        viewModel.findCategoryById(localId, serverId)
     }
 
     private fun setImgList(imgList: List<String>) {
@@ -179,32 +173,7 @@ class MoimMemoDetailActivity: AppCompatActivity(),
 
     override fun onClickYesButton(id: Int) {
         isDelete = true
-        //viewModel.patchMoimDiary(moimSchedule.scheduleId, "")
-        //diaryService.addGroupAfterDiary(moimSchedule.scheduleId, "")
-        //diaryService.addGroupAfterDiary(this)
         viewModel.deleteMoimMemo(moimSchedule.scheduleId)
-    }
-
-    suspend fun patchSuccess(response: DiaryResponse) {
-        if (isDelete) {
-            withContext(Dispatchers.IO) {
-                placeIntList.map { placeIndex ->
-                    diaryService.deleteGroupDiary(placeIndex, object : DiaryBasicView {
-                        override fun onSuccess(response: DiaryResponse) {
-                            Log.e("DELETE_GROUP_DIARY", "SUCCESS")
-                        }
-
-                        override fun onFailure(message: String) {
-                            Log.e("DELETE_GROUP_DIARY", message)
-                        }
-                    })
-                }
-                finish()
-                isDelete = false
-            }
-        } else {
-            finish()
-        }
     }
 
     /** 글자 수 반환 **/

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/diary/PersonalDetailActivity.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/diary/PersonalDetailActivity.kt
@@ -169,7 +169,7 @@ class PersonalDetailActivity : AppCompatActivity(), ConfirmDialogInterface {  //
         viewModel.imgList.observe(this) {
             galleryAdapter.addImages(it)
         }
-        viewModel.isDeleteComplete.observe(this) { isComplete ->
+        viewModel.deleteDiaryResult.observe(this) { isComplete ->
             // 다이어리 삭제 작업이 완료되었을 때 finish() 호출
             if (isComplete) {
                 Toast.makeText(this, "기록이 삭제되었습니다.", Toast.LENGTH_SHORT).show()

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/group/calendar/GroupCalendarMonthFragment.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/group/calendar/GroupCalendarMonthFragment.kt
@@ -164,12 +164,13 @@ class GroupCalendarMonthFragment : Fragment() {
 
             override fun onDiaryIconClicked(groupSchedule: MoimScheduleBody) { // 기록 아이콘 클릭
                 Log.d("GROUP_DIARY_CLICK", groupSchedule.toString())
-                val intent = Intent(context, MoimDiaryActivity::class.java)
-                intent.putExtra("hasGroupPlace",groupSchedule.hasDiaryPlace)
-                intent.putExtra("groupScheduleId", groupSchedule.moimScheduleId)
-                intent.putExtra("groupSchedule", groupSchedule)
-                intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP
-                requireActivity().startActivity(intent)
+                startActivity(Intent(context, MoimDiaryActivity::class.java)
+                    .putExtra("from", "groupCalendar")
+                    .putExtra("hasMoimPlace", groupSchedule.hasDiaryPlace)
+                    .putExtra("moimScheduleId", groupSchedule.moimScheduleId)
+                    .putExtra("moimSchedule", groupSchedule)
+                    .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
+                )
             }
         })
     }

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/group/diary/MoimDiaryActivity.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/group/diary/MoimDiaryActivity.kt
@@ -242,9 +242,7 @@ class MoimDiaryActivity : AppCompatActivity(),
     // 삭제 다이얼로그 확인 버튼
     override fun onClickYesButton(id: Int) {
         // 모임 기록 전체 삭제
-        lifecycleScope.launch {
-            viewModel.deleteMoimDiary(moimScheduleId)
-        }
+        viewModel.deleteMoimDiary(moimScheduleId)
     }
 
     @SuppressLint("ClickableViewAccessibility")

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/group/diary/MoimDiaryActivity.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/group/diary/MoimDiaryActivity.kt
@@ -19,11 +19,9 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityCompat
-import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import org.joda.time.DateTime
 import com.mongmong.namo.R
 import com.mongmong.namo.data.remote.diary.*
 import com.mongmong.namo.databinding.ActivityMoimDiaryBinding
@@ -31,19 +29,21 @@ import com.mongmong.namo.domain.model.group.MoimActivity
 import com.mongmong.namo.domain.model.group.MoimDiaryResult
 import com.mongmong.namo.domain.model.group.MoimScheduleBody
 import com.mongmong.namo.domain.model.group.MoimScheduleMember
+import com.mongmong.namo.presentation.ui.MainActivity
 import com.mongmong.namo.presentation.ui.group.diary.adapter.MoimActivityItemDecoration
-import com.mongmong.namo.presentation.ui.group.diary.adapter.MoimMemberRVAdapter
 import com.mongmong.namo.presentation.ui.group.diary.adapter.MoimActivityRVAdapter
+import com.mongmong.namo.presentation.ui.group.diary.adapter.MoimMemberRVAdapter
 import com.mongmong.namo.presentation.utils.CalendarUtils.Companion.dpToPx
 import com.mongmong.namo.presentation.utils.ConfirmDialog
 import com.mongmong.namo.presentation.utils.ConfirmDialogInterface
 import com.mongmong.namo.presentation.utils.PermissionChecker
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.*
+import org.joda.time.DateTime
 import java.text.NumberFormat
 import java.text.SimpleDateFormat
 import java.util.*
-import kotlin.collections.ArrayList
+
 
 @AndroidEntryPoint
 class MoimDiaryActivity : AppCompatActivity(),
@@ -83,8 +83,8 @@ class MoimDiaryActivity : AppCompatActivity(),
 
         repo = DiaryRepository(this)
 
-        moimScheduleId = intent.getLongExtra("groupScheduleId", 0L)  // 그룹 스케줄 아이디
-        val getHasDiaryBoolean = intent.getBooleanExtra("hasGroupPlace", false)
+        moimScheduleId = intent.getLongExtra("moimScheduleId", 0L)  // 그룹 스케줄 아이디
+        val getHasDiaryBoolean = intent.getBooleanExtra("hasMoimPlace", false)
 
         hasDiaryPlace(getHasDiaryBoolean)
         onClickListener()
@@ -94,7 +94,7 @@ class MoimDiaryActivity : AppCompatActivity(),
 
     private fun hasDiaryPlace(getHasDiaryBoolean: Boolean) {
         if (!getHasDiaryBoolean) {  // groupPlace가 없을 때, 저장하기
-            moimScheduleBody = intent?.getSerializableExtra("groupSchedule") as MoimScheduleBody
+            moimScheduleBody = intent?.getSerializableExtra("moimSchedule") as MoimScheduleBody
             Log.d("hasDiaryPlace", "$moimScheduleBody")
             activities.add(MoimActivity(0L, "", 0, arrayListOf(), arrayListOf()))
 
@@ -200,7 +200,13 @@ class MoimDiaryActivity : AppCompatActivity(),
         }
 
         viewModel.deleteDiaryComplete.observe(this) { isComplete ->
-            if(isComplete) finish()
+            if(isComplete) {
+                if(intent.getStringExtra("from") == "moimMemo") {
+                    startActivity(Intent(this, MainActivity::class.java)
+                            .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP))
+                }
+                else finish()
+            }
             else Toast.makeText(this, "네트워크 오류", Toast.LENGTH_SHORT).show()
         }
     }

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/group/diary/MoimDiaryViewModel.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/group/diary/MoimDiaryViewModel.kt
@@ -12,6 +12,7 @@ import com.mongmong.namo.domain.repositories.DiaryRepository
 import com.mongmong.namo.domain.usecase.FindCategoryUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 @HiltViewModel
@@ -124,7 +125,9 @@ class MoimDiaryViewModel @Inject constructor(
     }
 
     /** 모임 기록 삭제 (그룹에서) **/
-    suspend fun deleteMoimDiary(scheduleId: Long) {
-        _deleteDiaryComplete.postValue(repository.deleteMoimDiary(scheduleId))
+    fun deleteMoimDiary(scheduleId: Long) {
+        viewModelScope.launch {
+            _deleteDiaryComplete.postValue(repository.deleteMoimDiary(scheduleId))
+        }
     }
 }


### PR DESCRIPTION
## Related Issue
- #189 

## Type of change
<!-- 작업의 종류를 선택해주세요. -->
- [ ] Feature : 새로운 기능 추가
- [x] Bug fix : 버그 수정
- [x] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [ ] Style : 코드 스타일 및 포맷팅 작업
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## PR Desciption
> 변경 사항 설명
- 모임 메모, 모임 기록 삭제 api 연동
- 삭제 완료 됐음에도 finish가 안되는 버그 수정
- 모임 메모 -> 모임 기록 경로로 화면 이동했을 경우 모임 기록 삭제 시 화면 이동 로직 

## Requirements for Reviewer
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

모임 기록 삭제 후 화면 이동 로직을 구현할 때,
일단 intent로 어느 액티비티에서 접근했는지 넘겨고 if else문으로 해결했는데 다른 방법이 있을까요?

## PR Log

> PR 작업하면서 고민했던 내용, 해결한 내용, 고민 중인 내용 등

### 새롭게 배운 것

- 

### 고민 중인 사항

- 

## 첨부 자료

-
