### PR TITLE
[Refactor/207] 모임 메모 디테일 화면 리팩토링

### DIFF
--- a/app/src/main/java/com/mongmong/namo/data/datasource/diary/RemoteDiaryDataSource.kt
+++ b/app/src/main/java/com/mongmong/namo/data/datasource/diary/RemoteDiaryDataSource.kt
@@ -10,6 +10,8 @@ import com.mongmong.namo.domain.model.DiaryResponse
 import com.mongmong.namo.domain.model.GetScheduleId
 import com.mongmong.namo.data.utils.RequestConverter.convertTextRequest
 import com.mongmong.namo.data.utils.RequestConverter.imageToMultipart
+import com.mongmong.namo.domain.model.GetDiaryResponse
+import com.mongmong.namo.domain.model.GetDiaryResult
 import com.mongmong.namo.domain.model.group.GetMoimDiaryResponse
 import com.mongmong.namo.domain.model.group.MoimDiaryResult
 import kotlinx.coroutines.Dispatchers
@@ -109,6 +111,18 @@ class RemoteDiaryDataSource @Inject constructor(
         return diaryResponse.result
     }
 
+    suspend fun getMoimMemo(scheduleId: Long): GetDiaryResponse = withContext(Dispatchers.IO) {
+        var response = GetDiaryResponse(GetDiaryResult("", emptyList()))
+        runCatching {
+            diaryApiService.getDiary(scheduleId)
+        }.onSuccess {
+            Log.d("RemoteDiaryDataSource getMoimMemo Success", "$it")
+            response = it
+        }.onFailure {
+            Log.d("RemoteDiaryDataSource getMoimMemo Failure", "$it")
+        }
+        return@withContext response
+    }
     suspend fun patchMoimMemo(scheduleId: Long, content: String): Boolean {
         var isSuccess = false
         withContext(Dispatchers.IO) {

--- a/app/src/main/java/com/mongmong/namo/data/remote/DiaryApiService.kt
+++ b/app/src/main/java/com/mongmong/namo/data/remote/DiaryApiService.kt
@@ -4,6 +4,7 @@ import com.mongmong.namo.domain.model.DiaryAddResponse
 import com.mongmong.namo.domain.model.DiaryGetAllResponse
 import com.mongmong.namo.domain.model.DiaryGetMonthResponse
 import com.mongmong.namo.domain.model.DiaryResponse
+import com.mongmong.namo.domain.model.GetDiaryResponse
 import com.mongmong.namo.domain.model.group.GetMoimDiaryResponse
 import com.mongmong.namo.presentation.config.BaseResponse
 import retrofit2.Call
@@ -16,6 +17,12 @@ interface DiaryApiService {
     // 개인 기록 전체 조회
     @GET("diaries/all")
     fun getAllDiary(): Call<DiaryGetAllResponse>
+
+    // 개인 기록 개별 조회
+    @GET("diaries/{scheduleId}")
+    fun getDiary(
+        @Path("scheduleId") scheduleId: Long
+    ):GetDiaryResponse
 
     // 개인 기록 추가
     @Multipart
@@ -68,13 +75,5 @@ interface DiaryApiService {
     suspend fun deleteMoimMemo(
         @Path("scheduleId") scheduleId: Long,
     ): DiaryResponse
-
-    // 월별 모임 기록 조회2
-    @GET("group/diaries/month/{month}")
-    fun getGroupMonthDiary2(
-        @Path("month") month: String,
-        @Query("page") page: Int,
-        @Query("size") size: Int
-    ): Call<DiaryGetMonthResponse>
 }
 

--- a/app/src/main/java/com/mongmong/namo/data/remote/diary/DiaryService.kt
+++ b/app/src/main/java/com/mongmong/namo/data/remote/diary/DiaryService.kt
@@ -322,7 +322,7 @@ class DiaryService {
         page: Int,
         size: Int
     ) {
-        diaryRetrofitInterface.getGroupMonthDiary2(month, page, size)
+        /*diaryRetrofitInterface.getGroupMonthDiary2(month, page, size)
             .enqueue(object : Callback<DiaryGetMonthResponse> {
 
                 @SuppressLint("SuspiciousIndentation")
@@ -346,7 +346,7 @@ class DiaryService {
                 ) {
                     getGroupMonthView.onGetGroupMonthFailure(t.message.toString())
                 }
-            })
+            })*/
     }
 }
 

--- a/app/src/main/java/com/mongmong/namo/data/repositoriyImpl/DiaryRepositoryImpl.kt
+++ b/app/src/main/java/com/mongmong/namo/data/repositoriyImpl/DiaryRepositoryImpl.kt
@@ -11,6 +11,7 @@ import com.mongmong.namo.data.local.entity.diary.Diary
 import com.mongmong.namo.data.remote.NetworkChecker
 import com.mongmong.namo.domain.model.DiarySchedule
 import com.mongmong.namo.data.remote.DiaryApiService
+import com.mongmong.namo.domain.model.GetDiaryResponse
 import com.mongmong.namo.domain.model.group.MoimDiaryResult
 import com.mongmong.namo.domain.repositories.DiaryRepository
 import com.mongmong.namo.presentation.config.RoomState
@@ -107,6 +108,12 @@ class DiaryRepositoryImpl @Inject constructor(
     /** 모임 기록 개별 조회 **/
     override suspend fun getMoimDiary(scheduleId: Long): MoimDiaryResult {
         return remoteDiaryDataSource.getMoimDiary(scheduleId)
+    }
+
+    /** 모임 메모 개별 조회 **/
+    override suspend fun getMoimMemo(scheduleId: Long): GetDiaryResponse {
+        // 개인 기록 개별 조회 api 사용
+        return remoteDiaryDataSource.getMoimMemo(scheduleId)
     }
 
     /** 모임 기록 메모 추가/수정 **/

--- a/app/src/main/java/com/mongmong/namo/domain/model/Diary.kt
+++ b/app/src/main/java/com/mongmong/namo/domain/model/Diary.kt
@@ -4,6 +4,16 @@ import com.mongmong.namo.presentation.config.BaseResponse
 import com.google.gson.annotations.SerializedName
 
 
+data class GetDiaryResponse(
+    val result:GetDiaryResult
+): BaseResponse()
+
+data class GetDiaryResult(
+    val contents: String,
+    val urls: List<String>
+)
+
+
 data class DiaryResponse(
     val result: String
 ) : BaseResponse() // 기본 string
@@ -56,14 +66,13 @@ data class GroupResult(
 )
 
 data class MoimDiary(
-    @SerializedName("scheduleId") val scheduleId: Long,
-    @SerializedName("name") val title: String,
+    @SerializedName("scheduleId") var scheduleId: Long,
+    @SerializedName("name") var title: String,
     @SerializedName("startDate") var startDate: Long,
-    @SerializedName("contents") val content: String?,
-    @SerializedName("urls") val imgUrl: List<String>,
-    @SerializedName("categoryId") val categoryId: Long,
-    @SerializedName("color") val categoryColor: Long,
-    @SerializedName("placeName") val placeName: String
+    @SerializedName("contents") var content: String?,
+    @SerializedName("urls") var imgUrl: List<String>,
+    @SerializedName("categoryId") var categoryId: Long,
+    @SerializedName("placeName") var placeName: String
 ) : java.io.Serializable
 
 

--- a/app/src/main/java/com/mongmong/namo/domain/repositories/DiaryRepository.kt
+++ b/app/src/main/java/com/mongmong/namo/domain/repositories/DiaryRepository.kt
@@ -3,6 +3,8 @@ package com.mongmong.namo.domain.repositories
 import androidx.paging.PagingSource
 import com.mongmong.namo.data.local.entity.diary.Diary
 import com.mongmong.namo.domain.model.DiarySchedule
+import com.mongmong.namo.domain.model.GetDiaryResponse
+import com.mongmong.namo.domain.model.GetDiaryResult
 import com.mongmong.namo.domain.model.group.MoimDiaryResult
 
 
@@ -33,6 +35,8 @@ interface DiaryRepository {
     fun getMoimDiaryPagingSource(month: String): PagingSource<Int, DiarySchedule>
 
     suspend fun getMoimDiary(scheduleId: Long): MoimDiaryResult
+
+    suspend fun getMoimMemo(scheduleId: Long): GetDiaryResponse
 
     suspend fun patchMoimMemo(scheduleId: Long, content: String): Boolean
 

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/diary/DiaryDetailViewModel.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/diary/DiaryDetailViewModel.kt
@@ -8,6 +8,8 @@ import androidx.lifecycle.viewModelScope
 import com.mongmong.namo.data.local.entity.diary.Diary
 import com.mongmong.namo.data.local.entity.home.Category
 import com.mongmong.namo.data.local.entity.home.Schedule
+import com.mongmong.namo.domain.model.GetDiaryResponse
+import com.mongmong.namo.domain.model.MoimDiary
 import com.mongmong.namo.domain.model.group.MoimDiaryResult
 import com.mongmong.namo.domain.repositories.DiaryRepository
 import com.mongmong.namo.domain.usecase.FindCategoryUseCase
@@ -44,6 +46,8 @@ class DiaryDetailViewModel @Inject constructor(
     private val _category = MutableLiveData<Category>()
     val category: LiveData<Category> = _category
 
+    private val _getMoimMemoResponse = MutableLiveData<GetDiaryResponse>()
+    val getMoimMemoResponse: LiveData<GetDiaryResponse> = _getMoimMemoResponse
 
     /** 개인 기록 **/
     // 개인 기록 개별 조회
@@ -106,6 +110,12 @@ class DiaryDetailViewModel @Inject constructor(
         viewModelScope.launch {
             Log.d("MoimDiaryViewModel getMoimDiary", "$scheduleId")
             _getMoimDiaryResult.postValue(repository.getMoimDiary(scheduleId))
+        }
+    }
+
+    fun getMoimMemo(scheduleId: Long) {
+        viewModelScope.launch {
+            _getMoimMemoResponse.postValue(repository.getMoimMemo(scheduleId))
         }
     }
 

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/diary/DiaryFragment.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/diary/DiaryFragment.kt
@@ -196,14 +196,18 @@ class DiaryFragment : Fragment() {  // 다이어리 리스트 화면(bottomNavi)
     }
 
     private fun onDetailClickListener(item: DiarySchedule) {  // 그룹 기록 수정 클릭리스너
-
-        val monthDiary = MoimDiary(
-            item.scheduleId, item.title, item.startDate, item.content,
-            item.images ?: emptyList(), item.categoryId, 0L, item.place
+        val moimDiary = MoimDiary(
+            item.scheduleId,
+            item.title,
+            item.startDate,
+            item.content,
+            item.images ?: emptyList(),
+            item.categoryId,
+            item.place
         )
 
         requireActivity().startActivity(Intent(context, MoimMemoDetailActivity::class.java)
-                .putExtra("groupDiary", monthDiary))
+                .putExtra("moimDiary", moimDiary))
 
     }
 

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/diary/MoimMemoDetailActivity.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/diary/MoimMemoDetailActivity.kt
@@ -59,7 +59,6 @@ class MoimMemoDetailActivity: AppCompatActivity(),
 
     private fun initContent() {
         if(moimDiary.content == "") {
-            Log.d("시발2", "${moimDiary.content}")
             viewModel.getMoimMemo(moimDiary.scheduleId)
         } else {
             moimDiary.content?.let {

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/group/calendar/GroupCalendarMonthFragment.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/group/calendar/GroupCalendarMonthFragment.kt
@@ -165,7 +165,7 @@ class GroupCalendarMonthFragment : Fragment() {
                 Log.d("GROUP_DIARY_CLICK", groupSchedule.toString())
                 startActivity(Intent(context, MoimDiaryActivity::class.java)
                     .putExtra("from", "groupCalendar")
-                    .putExtra("hasMoimPlace", groupSchedule.hasDiaryPlace)
+                    .putExtra("hasMoimActivity", groupSchedule.hasDiaryPlace)
                     .putExtra("moimScheduleId", groupSchedule.moimScheduleId)
                     .putExtra("moimSchedule", groupSchedule)
                     .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/group/diary/MoimDiaryActivity.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/group/diary/MoimDiaryActivity.kt
@@ -84,18 +84,18 @@ class MoimDiaryActivity : AppCompatActivity(),
         repo = DiaryRepository(this)
 
         moimScheduleId = intent.getLongExtra("moimScheduleId", 0L)  // 그룹 스케줄 아이디
-        val getHasDiaryBoolean = intent.getBooleanExtra("hasMoimPlace", false)
 
-        hasDiaryPlace(getHasDiaryBoolean)
+        hasDiaryPlace()
         onClickListener()
 
         initObserve()
     }
 
-    private fun hasDiaryPlace(getHasDiaryBoolean: Boolean) {
-        if (!getHasDiaryBoolean) {  // groupPlace가 없을 때, 저장하기
+    private fun hasDiaryPlace() {
+        if (!intent.getBooleanExtra("hasMoimActivity", false)) {
+            // moimActivity가 없을 때, 저장하기
             moimScheduleBody = intent?.getSerializableExtra("moimSchedule") as MoimScheduleBody
-            Log.d("hasDiaryPlace", "$moimScheduleBody")
+
             activities.add(MoimActivity(0L, "", 0, arrayListOf(), arrayListOf()))
 
             setViewOnNoDiary()
@@ -106,7 +106,7 @@ class MoimDiaryActivity : AppCompatActivity(),
                 elevation = 0f
             }
             binding.diaryDeleteIv.visibility = View.GONE
-        } else { // groupPlace가 있을 때, 서버에서 데이터 가져오고 수정하기
+        } else { // moimActivity가 있을 때, 서버에서 데이터 가져오고 수정하기
             viewModel.getMoimDiary(moimScheduleId)
             binding.groupSaveTv.apply {
                 text = resources.getString(R.string.diary_edit)

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/home/adapter/DailyGroupRVAdapter.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/home/adapter/DailyGroupRVAdapter.kt
@@ -25,7 +25,7 @@ class DailyGroupRVAdapter : RecyclerView.Adapter<DailyGroupRVAdapter.ViewHolder>
 
     interface MoimScheduleClickListener {
         fun onContentClicked(schedule: Schedule)
-        fun onDiaryIconClicked(monthDiary: MoimDiary?)
+        fun onDiaryIconClicked(schedule: Schedule)
     }
 
     fun setMoimScheduleClickListener(moimScheduleClickListener: MoimScheduleClickListener) {
@@ -49,16 +49,8 @@ class DailyGroupRVAdapter : RecyclerView.Adapter<DailyGroupRVAdapter.ViewHolder>
         }
         // 기록 아이콘 클릭
         holder.binding.itemCalendarScheduleRecord.setOnClickListener {
-            val newCategoryId = schedules[position].categoryServerId
-
-            val diary = moimDiary.find {
-                it.scheduleId == schedules[position].serverId
-            }
-            Log.d("DailyGroupRVAdapter", "diary: $diary")
-
-            if (diary != null) {
-                val updatedDiary = diary.copy(categoryId = newCategoryId)
-                moimScheduleClickListener.onDiaryIconClicked(updatedDiary)
+            if (schedules[position].hasDiary != null) {
+                moimScheduleClickListener.onDiaryIconClicked(schedules[position])
             }
         }
     }

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/home/calendar/CalendarMonthFragment.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/home/calendar/CalendarMonthFragment.kt
@@ -176,10 +176,21 @@ class CalendarMonthFragment : Fragment(), GetGroupMonthView {
                 requireActivity().startActivity(intent)
             }
 
-            override fun onDiaryIconClicked(monthDiary: MoimDiary?) { // 기록 아이콘 클릭
-                val intent = Intent(context, MoimMemoDetailActivity::class.java)
-                intent.putExtra("groupDiary", monthDiary)
-                requireActivity().startActivity(intent)
+            override fun onDiaryIconClicked(schedule: Schedule) { // 기록 아이콘 클릭
+                val monthDiary = MoimDiary(
+                    schedule.serverId,
+                    schedule.title,
+                    schedule.startLong,
+                    "",
+                    emptyList(),
+                    schedule.categoryId,
+                    schedule.placeName
+                )
+
+                requireActivity().startActivity(
+                    Intent(context, MoimMemoDetailActivity::class.java)
+                        .putExtra("moimDiary", monthDiary)
+                )
             }
         })
     }
@@ -206,7 +217,6 @@ class CalendarMonthFragment : Fragment(), GetGroupMonthView {
         binding.homeDailyHeaderTv.text = monthDayList[dateId].toString("MM.dd (E)")
         binding.dailyScrollSv.scrollTo(0, 0)
         // 일정 아이템 표시
-        getMoimDiary() // 다이어리
         getSchedule(dateId) // 일정 내용
         Log.d("CHECK_GROUP_EVENT", monthGroupSchedule.toString())
     }
@@ -238,16 +248,6 @@ class CalendarMonthFragment : Fragment(), GetGroupMonthView {
         scheduleMoim = monthGroupSchedule.filter { item -> item.startLong <= todayEnd && item.endLong >= todayStart } as ArrayList<Schedule>
         groupScheduleRVAdapter.addGroup(scheduleMoim)
         setMoimEmptyText(scheduleMoim.isEmpty())
-    }
-
-    private fun getMoimDiary() {
-        try {
-            val service = DiaryService()
-            service.getGroupMonthDiary2(yearMonthDate(millis), 0, 50)
-            service.getGroupMonthView(this@CalendarMonthFragment)
-        } catch (e: java.lang.Exception) {
-            Log.e("Exception", "Exception occurred: ${e.message}")
-        }
     }
 
     private fun initObserve() {


### PR DESCRIPTION
## Related Issue
- #207 

## Type of change
<!-- 작업의 종류를 선택해주세요. -->
- [ ] Feature : 새로운 기능 추가
- [ ] Bug fix : 버그 수정
- [x] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [ ] Style : 코드 스타일 및 포맷팅 작업
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## PR Desciption
> 변경 사항 설명
### 기존
이전 화면에서 데이터를 받아오기 위해 기록 전체 조회/비교 후 데이터를 넘겨줌
### 개선
schedule 데이터로 moimDiary 데이터를 채운 후 넘겨줌
추가로 필요한 데이터는 기록과 모임 기록 개별 조회 api로 채움
-> 캘린더 일정에서 기록 호출 필요 x, getGroupMonthDiary2 api 삭제

## Requirements for Reviewer
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

-

## PR Log

> PR 작업하면서 고민했던 내용, 해결한 내용, 고민 중인 내용 등

### 새롭게 배운 것

- 

### 고민 중인 사항

- 

## 첨부 자료

-
