### PR TITLE
[Fix/206] 개인 일정 타임피커 초기화 이슈 해결

### DIFF
--- a/app/src/main/java/com/mongmong/namo/presentation/ui/home/schedule/ScheduleDialogBasicFragment.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/home/schedule/ScheduleDialogBasicFragment.kt
@@ -194,10 +194,6 @@ class ScheduleDialogBasicFragment : Fragment() {
             this.minute = startDateTime.minuteOfHour
             this.setOnTimeChangedListener { view, hourOfDay, minute ->
                 startDateTime = startDateTime.withTime(hourOfDay, minute, 0,0)
-                if (startDateTime.millis > endDateTime.millis) {
-                    endDateTime = endDateTime.withTime(hourOfDay, minute, 0, 0)
-                    binding.dialogScheduleEndTimeTv.text = endDateTime.toString(getString(R.string.timeFormat))
-                }
                 binding.dialogScheduleStartTimeTv.text = startDateTime.toString(getString(R.string.timeFormat))
             }
         }
@@ -207,10 +203,6 @@ class ScheduleDialogBasicFragment : Fragment() {
             this.minute = endDateTime.minuteOfHour
             this.setOnTimeChangedListener { view, hourOfDay, minute ->
                 endDateTime = endDateTime.withTime(hourOfDay, minute, 0,0)
-                if (endDateTime.millis < startDateTime.millis) {
-                    startDateTime = startDateTime.withTime(hourOfDay, minute, 0, 0)
-                    binding.dialogScheduleStartTimeTv.text = startDateTime.toString(getString(R.string.timeFormat))
-                }
                 binding.dialogScheduleEndTimeTv.text = endDateTime.toString(getString(R.string.timeFormat))
             }
         }
@@ -309,10 +301,7 @@ class ScheduleDialogBasicFragment : Fragment() {
 
         // 저장 클릭
         binding.dialogScheduleSaveBtn.setOnClickListener {
-            if (binding.dialogScheduleTitleEt.text.toString().isEmpty()) {
-                Toast.makeText(context, "일정 제목을 입력해주세요.", Toast.LENGTH_SHORT).show()
-                return@setOnClickListener
-            }
+            if (!isValidInput()) return@setOnClickListener
             storeContent()
 
             // 모임 일정일 경우
@@ -332,6 +321,20 @@ class ScheduleDialogBasicFragment : Fragment() {
                 }
             }
         }
+    }
+
+    private fun isValidInput(): Boolean {
+        // 제목 미입력
+        if (binding.dialogScheduleTitleEt.text.toString().isEmpty()) {
+            Toast.makeText(context, "일정 제목을 입력해주세요.", Toast.LENGTH_SHORT).show()
+            return false
+        }
+        // 시작일 > 종료일
+        if (startDateTime.millis > endDateTime.millis) {
+            Toast.makeText(context, "시작일이 종료일보다 빠를 수 없습니다.", Toast.LENGTH_SHORT).show()
+            return false
+        }
+        return true
     }
 
     private fun setTextViewsInactive(vararg textViews: TextView) {

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/home/schedule/ScheduleDialogBasicFragment.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/home/schedule/ScheduleDialogBasicFragment.kt
@@ -151,18 +151,14 @@ class ScheduleDialogBasicFragment : Fragment() {
     }
 
     private fun setInit() {
+        val nowDay = args.nowDay
+
         if (args.schedule != null) {
             schedule = args.schedule!!
             findCategory(schedule)
             prevAlarmList = schedule.alarmList
         } else {
             binding.dialogScheduleHeaderTv.text = "새 일정"
-            val nowDay = args.nowDay
-            if (nowDay != 0L) {
-                date = DateTime(args.nowDay)
-            }
-            initPickerText()
-            initCategory()
         }
 
         binding.dialogScheduleHeaderTv.text = "새 일정"
@@ -173,7 +169,8 @@ class ScheduleDialogBasicFragment : Fragment() {
             binding.dialogScheduleHeaderTv.text = "모임 일정 편집"
             inactivateMoimScheduleEdit() // 비활성화 처리
         }
-
+        initPickerText()
+        initCategory()
         Log.e("ScheduleDialogFrag", "schedule: $schedule")
     }
 
@@ -187,50 +184,55 @@ class ScheduleDialogBasicFragment : Fragment() {
             findNavController().navigate(action)
         }
 
-        // picker 클릭
-        binding.dialogScheduleStartTimeTp.currentHour = startDateTime.hourOfDay
-        binding.dialogScheduleStartTimeTp.currentMinute = startDateTime.minuteOfHour
-        binding.dialogScheduleStartTimeTp.setOnTimeChangedListener { view, hourOfDay, minute ->
-            startDateTime = startDateTime.withTime(hourOfDay, minute, 0,0)
-            if (startDateTime.millis > endDateTime.millis) {
-                endDateTime = endDateTime.withTime(hourOfDay, minute, 0, 0)
-                binding.dialogScheduleEndTimeTv.text = endDateTime.toString(getString(R.string.timeFormat))
-            }
-            binding.dialogScheduleStartTimeTv.text = startDateTime.toString(getString(R.string.timeFormat))
-        }
-
-        binding.dialogScheduleEndTimeTp.currentHour = endDateTime.hourOfDay
-        binding.dialogScheduleEndTimeTp.currentMinute = endDateTime.minuteOfHour
-        binding.dialogScheduleEndTimeTp.setOnTimeChangedListener { view, hourOfDay, minute ->
-            endDateTime = endDateTime.withTime(hourOfDay, minute, 0, 0)
-            if (endDateTime.millis < startDateTime.millis) {
-                startDateTime = startDateTime.withTime(hourOfDay, minute, 0, 0)
+        /** picker 클릭 */
+        // 시작 시간
+        with(binding.dialogScheduleStartTimeTp) {
+            this.hour = startDateTime.hourOfDay
+            this.minute = startDateTime.minuteOfHour
+            this.setOnTimeChangedListener { view, hourOfDay, minute ->
+                startDateTime = startDateTime.withTime(hourOfDay, minute, 0,0)
+                if (startDateTime.millis > endDateTime.millis) {
+                    endDateTime = endDateTime.withTime(hourOfDay, minute, 0, 0)
+                    binding.dialogScheduleEndTimeTv.text = endDateTime.toString(getString(R.string.timeFormat))
+                }
                 binding.dialogScheduleStartTimeTv.text = startDateTime.toString(getString(R.string.timeFormat))
             }
-            binding.dialogScheduleEndTimeTv.text = endDateTime.toString(getString(R.string.timeFormat))
         }
-
+        // 종료 시간
+        with(binding.dialogScheduleEndTimeTp) {
+            this.hour = endDateTime.hourOfDay
+            this.minute = endDateTime.minuteOfHour
+            this.setOnTimeChangedListener { view, hourOfDay, minute ->
+                endDateTime = endDateTime.withTime(hourOfDay, minute, 0,0)
+                if (endDateTime.millis < startDateTime.millis) {
+                    startDateTime = startDateTime.withTime(hourOfDay, minute, 0, 0)
+                    binding.dialogScheduleStartTimeTv.text = startDateTime.toString(getString(R.string.timeFormat))
+                }
+                binding.dialogScheduleEndTimeTv.text = endDateTime.toString(getString(R.string.timeFormat))
+            }
+        }
+        // 시작일 - 날짜
         binding.dialogScheduleStartDateTv.setOnClickListener {
             hidekeyboard()
             showPicker(binding.dialogScheduleStartDateTv, binding.dialogScheduleDateLayout)
         }
-
+        // 종료일 - 날짜
         binding.dialogScheduleEndDateTv.setOnClickListener {
             hidekeyboard()
             showPicker(binding.dialogScheduleEndDateTv, binding.dialogScheduleDateLayout)
         }
-
+        // 시작일 - 시간
         binding.dialogScheduleStartTimeTv.setOnClickListener {
             hidekeyboard()
             showPicker(binding.dialogScheduleStartTimeTv, binding.dialogScheduleStartTimeLayout)
         }
-
+        // 종료일 - 시간
         binding.dialogScheduleEndTimeTv.setOnClickListener {
             hidekeyboard()
             showPicker(binding.dialogScheduleEndTimeTv, binding.dialogScheduleEndTimeLayout)
         }
 
-        //알람 클릭
+        // 알림 클릭
         binding.dialogScheduleAlarmLayout.setOnClickListener {
             hidekeyboard()
             if (!isAlarm) binding.dialogScheduleAlarmContentLayout.visibility = View.VISIBLE
@@ -699,6 +701,7 @@ class ScheduleDialogBasicFragment : Fragment() {
         binding.dialogScheduleEndDateTv.text = selectedDate.toString(getString(R.string.dateFormat))
         endDateTime = selectedDate
     }
+
     private fun initPickerText(){
         startDateTime = DateTime(date.year, date.monthOfYear, date.dayOfMonth, 8, 0, 0, 0)
         endDateTime = DateTime(date.year, date.monthOfYear, date.dayOfMonth, 9, 0, 0, 0)

--- a/app/src/main/java/com/mongmong/namo/presentation/utils/PickerConverter.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/utils/PickerConverter.kt
@@ -1,0 +1,34 @@
+package com.mongmong.namo.presentation.utils
+
+import org.joda.time.DateTime
+
+object PickerConverter {
+    private const val DATE_FORMAT = "yyyy.MM.dd (E)"
+    private const val TIME_FORMAT = "hh:mm a"
+    private const val DEFAULT_START_HOUR = 8 // 오전 8시
+    private const val DEFAULT_END_HOUR = 9 // 오전 9시
+
+    fun getDefaultDate(date: DateTime, isStartTime: Boolean): DateTime {
+        return DateTime(date.year, date.monthOfYear, date.dayOfMonth, if (isStartTime) DEFAULT_START_HOUR else DEFAULT_END_HOUR, 0, 0, 0)
+    }
+
+    fun parseDateTimeToDateText(dateTime: DateTime): String {
+        return dateTime.toString(DATE_FORMAT)
+    }
+
+    fun parseDateTimeToTimeText(dateTime: DateTime): String {
+        return dateTime.toString(TIME_FORMAT)
+    }
+
+    fun parseLongToDateTime(longDate: Long): DateTime {
+        return DateTime(longDate * 1000L)
+    }
+
+    fun setSelectedDate(year: Int, monthOfYear: Int, dayOfMonth: Int, dateTime: DateTime): DateTime {
+        return DateTime(year, monthOfYear + 1, dayOfMonth, dateTime.hourOfDay, dateTime.minuteOfHour)
+    }
+
+    fun setSelectedTime(prevDateTime: DateTime, hour: Int, minute: Int): DateTime {
+        return prevDateTime.withTime(hour, minute, 0, 0)
+    }
+}


### PR DESCRIPTION
## Related Issue
- #206 

## Type of change
<!-- 작업의 종류를 선택해주세요. -->
- [ ] Feature : 새로운 기능 추가
- [x] Bug fix : 버그 수정
- [ ] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [ ] Style : 코드 스타일 및 포맷팅 작업
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## PR Desciption
> 변경 사항 설명

- 피커의 시간이 무조건 현재 시간으로 표시되던 이슈를 해결했습니다.

## Requirements for Reviewer
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

- 피커를 돌려둔 상태로 다른 피커를 클릭하면 이전에 마지막으로 선택했던 시간이 아니라 시간이 이상하게 표시되는데, 조금 더 손봐야 할 부분인 것 같습니다.

## PR Log

> PR 작업하면서 고민했던 내용, 해결한 내용, 고민 중인 내용 등

### 새롭게 배운 것

- 

### 고민 중인 사항

- 

## 첨부 자료

-
