### PR TITLE
[Fix/210] 일정 바텀시트 좌우의 공간 삭제

### DIFF
--- a/app/src/main/res/layout/fragment_calendar_month.xml
+++ b/app/src/main/res/layout/fragment_calendar_month.xml
@@ -8,17 +8,19 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:orientation="vertical"
-        android:paddingStart="20dp"
-        android:paddingEnd="10dp"
         app:layoutDescription="@xml/fragment_calendar_month2_xml_constraintlayout_scene">
 
+        <!-- 캘린더 -->
         <com.mongmong.namo.presentation.ui.home.calendar.PersonalCalendarView
             android:id="@+id/calendar_month_view"
             android:layout_width="match_parent"
             android:layout_height="0dp"
+            android:layout_marginStart="@dimen/margin_calendar_start"
+            android:layout_marginEnd="@dimen/margin_calendar_end"
             app:layout_constraintBottom_toTopOf="@id/daily_layout"
             app:layout_constraintTop_toTopOf="parent" />
 
+        <!-- 바텀시트 -->
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/daily_layout"
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_group_calendar_month.xml
+++ b/app/src/main/res/layout/fragment_group_calendar_month.xml
@@ -9,14 +9,14 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:orientation="vertical"
-        android:paddingStart="20dp"
-        android:paddingEnd="10dp"
         app:layoutDescription="@xml/fragment_group_calendar_xml_constraintlayout2_scene">
 
         <com.mongmong.namo.presentation.ui.group.calendar.GroupCalendarView
             android:id="@+id/group_calendar_month_view"
             android:layout_width="match_parent"
             android:layout_height="0dp"
+            android:layout_marginStart="@dimen/margin_calendar_start"
+            android:layout_marginEnd="@dimen/margin_calendar_end"
             app:layout_constraintBottom_toTopOf="@id/group_daily_layout"
             app:layout_constraintTop_toTopOf="parent" />
 

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -10,5 +10,7 @@
     <dimen name="test_100">100dp</dimen>
     <dimen name="test_10">10dp</dimen>
     <dimen name="custom_setting_default_spacing">20dp</dimen>
+    <dimen name="margin_calendar_start">20dp</dimen>
+    <dimen name="margin_calendar_end">10dp</dimen>
 
 </resources>


### PR DESCRIPTION
## Related Issue
- #206 

## Type of change
<!-- 작업의 종류를 선택해주세요. -->
- [ ] Feature : 새로운 기능 추가
- [x] Bug fix : 버그 수정
- [ ] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [ ] Style : 코드 스타일 및 포맷팅 작업
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## PR Desciption
> 변경 사항 설명

![](https://github.com/Namo-Mongmong/Android/assets/101113025/697b5f6b-92fe-4c1e-9bec-24eb4c42cdda) 변경 전 | ![image](https://github.com/Namo-Mongmong/Android/assets/101113025/c5e7d23f-1691-49e1-8324-c25311426005) 변경 후
---|---|



- 캘린더 날짜 선택했을 때 올라오는 바텀시트 좌우의 공간을 삭제해 화면 너비에 꽉 차도록 구현했습니다.
- dimens에 좌/우 마진값을 저장


## Requirements for Reviewer
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

-

## PR Log

> PR 작업하면서 고민했던 내용, 해결한 내용, 고민 중인 내용 등

### 새롭게 배운 것

- 

### 고민 중인 사항

- 

## 첨부 자료

-
