### PR TITLE
[Fix/218] 앱에 처음 진입했을 때 캘린더에 모임 일정이 중복되어 표시되는 이슈 해결

### DIFF
--- a/app/src/main/java/com/mongmong/namo/presentation/ui/home/calendar/CalendarMonthFragment.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/home/calendar/CalendarMonthFragment.kt
@@ -12,11 +12,7 @@ import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.mongmong.namo.data.local.entity.home.Category
 import com.mongmong.namo.data.local.entity.home.Schedule
-import com.mongmong.namo.data.remote.diary.DiaryService
-import com.mongmong.namo.data.remote.diary.GetGroupMonthView
 import com.mongmong.namo.databinding.FragmentCalendarMonthBinding
-import com.mongmong.namo.domain.model.DiaryGetMonthResponse
-import com.mongmong.namo.domain.model.MoimDiary
 import com.mongmong.namo.presentation.ui.diary.MoimMemoDetailActivity
 import com.mongmong.namo.presentation.ui.diary.PersonalDetailActivity
 import com.mongmong.namo.presentation.ui.home.HomeFragment
@@ -30,7 +26,7 @@ import org.joda.time.DateTime
 import java.text.SimpleDateFormat
 
 @AndroidEntryPoint
-class CalendarMonthFragment : Fragment(), GetGroupMonthView {
+class CalendarMonthFragment : Fragment() {
 
     private lateinit var binding: FragmentCalendarMonthBinding
 
@@ -75,6 +71,7 @@ class CalendarMonthFragment : Fragment(), GetGroupMonthView {
     override fun onResume() {
         super.onResume()
 
+        clearSchedulesData()
         getCategoryList()
         setMonthCalendarSchedule(monthDayList[0].withTimeAtStartOfDay().millis / 1000, monthDayList[41].plusDays(1).withTimeAtStartOfDay().millis / 1000)
         setAdapter()
@@ -96,8 +93,7 @@ class CalendarMonthFragment : Fragment(), GetGroupMonthView {
 
     override fun onPause() {
         super.onPause()
-
-        calendarSchedules.clear()
+        clearSchedulesData()
     }
 
     private fun initClickListeners() {
@@ -146,6 +142,11 @@ class CalendarMonthFragment : Fragment(), GetGroupMonthView {
 //                binding.calendarMonthView.invalidate()
                 }
             }
+    }
+
+    private fun clearSchedulesData() {
+        calendarSchedules.clear()
+        monthGroupSchedule.clear()
     }
 
     private fun initAdapter() {
@@ -199,7 +200,7 @@ class CalendarMonthFragment : Fragment(), GetGroupMonthView {
     }
 
     private fun setCategoryList(categoryList: List<Category>) {
-        Log.d("CalendarMonthFrag", "categoryList: $categoryList")
+//        Log.d("CalendarMonthFrag", "categoryList: $categoryList")
         binding.calendarMonthView.setCategoryList(categoryList)
         personalScheduleRVAdapter.setCategory(categoryList)
         groupScheduleRVAdapter.setCategory(categoryList)
@@ -275,22 +276,13 @@ class CalendarMonthFragment : Fragment(), GetGroupMonthView {
         // 모임 일정 리스트
         viewModel.moimScheduleList.observe(viewLifecycleOwner) { result ->
             scheduleMoim.clear()
+            monthGroupSchedule.clear()
             if (!result.isNullOrEmpty()) {
                 monthGroupSchedule = result.map { it.convertServerScheduleResponseToLocal() } as ArrayList
                 calendarSchedules.addAll(monthGroupSchedule)
             }
             binding.calendarMonthView.setScheduleList(calendarSchedules) // 달력 표시
         }
-    }
-
-    override fun onGetGroupMonthSuccess(response: DiaryGetMonthResponse) {
-        Log.d("GET_GROUP_MONTH", "$response")
-        val data = response.result
-        groupScheduleRVAdapter.addGroupDiary(data.content as ArrayList<MoimDiary>)
-    }
-
-    override fun onGetGroupMonthFailure(message: String) {
-        Log.d("GET_GROUP_MONTH", message)
     }
 
     companion object {


### PR DESCRIPTION
## Related Issue
- #218 

## Type of change
<!-- 작업의 종류를 선택해주세요. -->
- [ ] Feature : 새로운 기능 추가
- [x] Bug fix : 버그 수정
- [ ] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [ ] Style : 코드 스타일 및 포맷팅 작업
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## PR Desciption
> 변경 사항 설명

https://github.com/Namo-Mongmong/Android/assets/101113025/57b432b3-9a0b-4102-bf33-f02050696553


- `onResume()` 및 `onPause()`에서 캘린더에 표시될 일정 리스트 초기화

## Requirements for Reviewer
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

-

## PR Log

> PR 작업하면서 고민했던 내용, 해결한 내용, 고민 중인 내용 등

### 새롭게 배운 것

- 

### 고민 중인 사항

- 

## 첨부 자료

- [관련 QA](https://mynamo.notion.site/0cb4651bb4aa4fb386767aef22ad8845?pvs=4)
