### PR TITLE
[Feat/225] 로그인 및 회원탈퇴 API 통신 방법 변경

### DIFF
--- a/app/src/main/java/com/mongmong/namo/data/datasource/auth/RemoteAuthDataSource.kt
+++ b/app/src/main/java/com/mongmong/namo/data/datasource/auth/RemoteAuthDataSource.kt
@@ -2,7 +2,7 @@ package com.mongmong.namo.data.datasource.auth
 
 import android.util.Log
 import com.mongmong.namo.data.remote.AuthApiService
-import com.mongmong.namo.domain.model.AccessTokenBody
+import com.mongmong.namo.domain.model.LoginBody
 import com.mongmong.namo.domain.model.LoginResponse
 import com.mongmong.namo.domain.model.LoginResult
 import com.mongmong.namo.domain.model.LogoutBody
@@ -17,7 +17,7 @@ class RemoteAuthDataSource @Inject constructor(
     private val authApiService: AuthApiService
 ) {
     suspend fun postKakaoLogin(
-        tokenBody: AccessTokenBody
+        tokenBody: LoginBody
     ): LoginResponse {
         var loginResponse = LoginResponse(
             result = LoginResult(
@@ -40,7 +40,7 @@ class RemoteAuthDataSource @Inject constructor(
     }
 
     suspend fun postNaverLogin(
-        tokenBody: AccessTokenBody
+        tokenBody: LoginBody
     ): LoginResponse {
         var loginResponse = LoginResponse(
             result = LoginResult(
@@ -102,12 +102,11 @@ class RemoteAuthDataSource @Inject constructor(
     }
 
     suspend fun postKakaoQuit(
-        tokenBody: AccessTokenBody
     ): Boolean {
         var isSuccess = false
         withContext(Dispatchers.IO) {
             runCatching {
-                authApiService.postKakaoQuit(tokenBody)
+                authApiService.postKakaoQuit()
             }.onSuccess {
                 Log.d("RemoteAuthDataSource", "postKakaoQuit Success $it")
                 isSuccess = true
@@ -119,12 +118,11 @@ class RemoteAuthDataSource @Inject constructor(
     }
 
     suspend fun postNaverQuit(
-        tokenBody: AccessTokenBody
     ): Boolean {
         var isSuccess = false
         withContext(Dispatchers.IO) {
             runCatching {
-                authApiService.postNaverQuit(tokenBody)
+                authApiService.postNaverQuit()
             }.onSuccess {
                 Log.d("RemoteAuthDataSource", "postNaverQuit Success $it")
                 isSuccess = true

--- a/app/src/main/java/com/mongmong/namo/data/datasource/auth/RemoteAuthDataSource.kt
+++ b/app/src/main/java/com/mongmong/namo/data/datasource/auth/RemoteAuthDataSource.kt
@@ -102,11 +102,12 @@ class RemoteAuthDataSource @Inject constructor(
     }
 
     suspend fun postKakaoQuit(
+        bearerToken: String
     ): Boolean {
         var isSuccess = false
         withContext(Dispatchers.IO) {
             runCatching {
-                authApiService.postKakaoQuit()
+                authApiService.postKakaoQuit(bearerToken)
             }.onSuccess {
                 Log.d("RemoteAuthDataSource", "postKakaoQuit Success $it")
                 isSuccess = true
@@ -118,11 +119,12 @@ class RemoteAuthDataSource @Inject constructor(
     }
 
     suspend fun postNaverQuit(
+        bearerToken: String
     ): Boolean {
         var isSuccess = false
         withContext(Dispatchers.IO) {
             runCatching {
-                authApiService.postNaverQuit()
+                authApiService.postNaverQuit(bearerToken)
             }.onSuccess {
                 Log.d("RemoteAuthDataSource", "postNaverQuit Success $it")
                 isSuccess = true

--- a/app/src/main/java/com/mongmong/namo/data/remote/AuthApiService.kt
+++ b/app/src/main/java/com/mongmong/namo/data/remote/AuthApiService.kt
@@ -6,7 +6,9 @@ import com.mongmong.namo.domain.model.LoginResponse
 import com.mongmong.namo.domain.model.LogoutBody
 import com.mongmong.namo.domain.model.RefreshResponse
 import com.mongmong.namo.domain.model.TokenBody
+import com.mongmong.namo.presentation.config.BaseResponse
 import retrofit2.http.Body
+import retrofit2.http.Header
 import retrofit2.http.POST
 
 interface AuthApiService {
@@ -38,9 +40,13 @@ interface AuthApiService {
     /** 회원탈퇴 */
     // 카카오 회원탈퇴
     @POST("auths/kakao/delete")
-    suspend fun postKakaoQuit(): AuthResponse
+    suspend fun postKakaoQuit(
+        @Header("authorization") accessToken: String
+    ): AuthResponse
 
     // 네이버 회원탈퇴
     @POST("auths/naver/delete")
-    suspend fun postNaverQuit(): AuthResponse
+    suspend fun postNaverQuit(
+        @Header("authorization") accessToken: String
+    ): BaseResponse
 }

--- a/app/src/main/java/com/mongmong/namo/data/remote/AuthApiService.kt
+++ b/app/src/main/java/com/mongmong/namo/data/remote/AuthApiService.kt
@@ -1,12 +1,11 @@
 package com.mongmong.namo.data.remote
 
-import com.mongmong.namo.domain.model.AccessTokenBody
+import com.mongmong.namo.domain.model.LoginBody
 import com.mongmong.namo.domain.model.AuthResponse
 import com.mongmong.namo.domain.model.LoginResponse
 import com.mongmong.namo.domain.model.LogoutBody
 import com.mongmong.namo.domain.model.RefreshResponse
 import com.mongmong.namo.domain.model.TokenBody
-import retrofit2.Call
 import retrofit2.http.Body
 import retrofit2.http.POST
 
@@ -15,13 +14,13 @@ interface AuthApiService {
     // SDK 카카오 로그인
     @POST("auths/kakao/signup")
     suspend fun postKakaoSDK(
-        @Body body: AccessTokenBody
+        @Body body: LoginBody
     ): LoginResponse
 
     // SDK 네이버 로그인
     @POST("auths/naver/signup")
     suspend fun postNaverSDK(
-        @Body body: AccessTokenBody
+        @Body body: LoginBody
     ): LoginResponse
 
     // 토큰 재발급
@@ -39,13 +38,9 @@ interface AuthApiService {
     /** 회원탈퇴 */
     // 카카오 회원탈퇴
     @POST("auths/kakao/delete")
-    suspend fun postKakaoQuit(
-        @Body body: AccessTokenBody
-    ): AuthResponse
+    suspend fun postKakaoQuit(): AuthResponse
 
     // 네이버 회원탈퇴
     @POST("auths/naver/delete")
-    suspend fun postNaverQuit(
-        @Body body: AccessTokenBody
-    ): AuthResponse
+    suspend fun postNaverQuit(): AuthResponse
 }

--- a/app/src/main/java/com/mongmong/namo/data/repositoriyImpl/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/mongmong/namo/data/repositoriyImpl/AuthRepositoryImpl.kt
@@ -1,7 +1,7 @@
 package com.mongmong.namo.data.repositoriyImpl
 
 import com.mongmong.namo.data.datasource.auth.RemoteAuthDataSource
-import com.mongmong.namo.domain.model.AccessTokenBody
+import com.mongmong.namo.domain.model.LoginBody
 import com.mongmong.namo.domain.model.LoginResponse
 import com.mongmong.namo.domain.model.LogoutBody
 import com.mongmong.namo.domain.model.RefreshResponse
@@ -12,12 +12,12 @@ import javax.inject.Inject
 class AuthRepositoryImpl @Inject constructor(
     private val remoteAuthDataSource: RemoteAuthDataSource
 ) : AuthRepository {
-    override suspend fun postKakaoLogin(accessToken: String): LoginResponse {
-        return remoteAuthDataSource.postKakaoLogin(AccessTokenBody(accessToken))
+    override suspend fun postKakaoLogin(body: LoginBody): LoginResponse {
+        return remoteAuthDataSource.postKakaoLogin(body)
     }
 
-    override suspend fun postNaverLogin(accessToken: String): LoginResponse {
-        return remoteAuthDataSource.postNaverLogin(AccessTokenBody(accessToken))
+    override suspend fun postNaverLogin(body: LoginBody): LoginResponse {
+        return remoteAuthDataSource.postNaverLogin(body)
     }
 
     override suspend fun postTokenRefresh(
@@ -31,11 +31,11 @@ class AuthRepositoryImpl @Inject constructor(
         return remoteAuthDataSource.postLogout(LogoutBody(accessToken))
     }
 
-    override suspend fun postKakaoQuit(accessToken: String): Boolean {
-        return remoteAuthDataSource.postKakaoQuit(AccessTokenBody(accessToken))
+    override suspend fun postKakaoQuit(): Boolean {
+        return remoteAuthDataSource.postKakaoQuit()
     }
 
-    override suspend fun postNaverQuit(accessToken: String): Boolean {
-        return remoteAuthDataSource.postNaverQuit(AccessTokenBody(accessToken))
+    override suspend fun postNaverQuit(): Boolean {
+        return remoteAuthDataSource.postNaverQuit()
     }
 }

--- a/app/src/main/java/com/mongmong/namo/data/repositoriyImpl/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/mongmong/namo/data/repositoriyImpl/AuthRepositoryImpl.kt
@@ -31,11 +31,11 @@ class AuthRepositoryImpl @Inject constructor(
         return remoteAuthDataSource.postLogout(LogoutBody(accessToken))
     }
 
-    override suspend fun postKakaoQuit(): Boolean {
-        return remoteAuthDataSource.postKakaoQuit()
+    override suspend fun postKakaoQuit(bearerToken: String): Boolean {
+        return remoteAuthDataSource.postKakaoQuit(bearerToken)
     }
 
-    override suspend fun postNaverQuit(): Boolean {
-        return remoteAuthDataSource.postNaverQuit()
+    override suspend fun postNaverQuit(bearerToken: String): Boolean {
+        return remoteAuthDataSource.postNaverQuit(bearerToken)
     }
 }

--- a/app/src/main/java/com/mongmong/namo/domain/model/Auth.kt
+++ b/app/src/main/java/com/mongmong/namo/domain/model/Auth.kt
@@ -43,9 +43,3 @@ data class LoginBody(
 data class LogoutBody(
     val accessToken: String
 )
-
-// 로그인 한 SDK 정보
-data class SdkInfo(
-    val platform: String,
-    val accessToken: String
-)

--- a/app/src/main/java/com/mongmong/namo/domain/model/Auth.kt
+++ b/app/src/main/java/com/mongmong/namo/domain/model/Auth.kt
@@ -35,8 +35,9 @@ data class TokenBody(
     val refreshToken: String
 )
 
-data class AccessTokenBody(
-    val accessToken: String
+data class LoginBody(
+    val accessToken: String,
+    val socialRefreshToken: String
 )
 
 data class LogoutBody(

--- a/app/src/main/java/com/mongmong/namo/domain/repositories/AuthRepository.kt
+++ b/app/src/main/java/com/mongmong/namo/domain/repositories/AuthRepository.kt
@@ -28,7 +28,11 @@ interface AuthRepository {
 
     /** 회원탈퇴 */
     // 카카오
-    suspend fun postKakaoQuit(): Boolean
+    suspend fun postKakaoQuit(
+        bearerToken: String
+    ): Boolean
     // 네이버
-    suspend fun postNaverQuit(): Boolean
+    suspend fun postNaverQuit(
+        bearerToken: String
+    ): Boolean
 }

--- a/app/src/main/java/com/mongmong/namo/domain/repositories/AuthRepository.kt
+++ b/app/src/main/java/com/mongmong/namo/domain/repositories/AuthRepository.kt
@@ -1,18 +1,18 @@
 package com.mongmong.namo.domain.repositories
 
+import com.mongmong.namo.domain.model.LoginBody
 import com.mongmong.namo.domain.model.LoginResponse
 import com.mongmong.namo.domain.model.RefreshResponse
-import com.mongmong.namo.domain.model.TokenBody
 
 interface AuthRepository {
     /** 로그인 */
     // 카카오
     suspend fun postKakaoLogin(
-        accessToken: String
+        body: LoginBody
     ): LoginResponse
     // 네이버
     suspend fun postNaverLogin(
-        accessToken: String
+        body: LoginBody
     ): LoginResponse
 
     /** 토큰 재발급 */
@@ -28,11 +28,7 @@ interface AuthRepository {
 
     /** 회원탈퇴 */
     // 카카오
-    suspend fun postKakaoQuit(
-        accessToken: String
-    ): Boolean
+    suspend fun postKakaoQuit(): Boolean
     // 네이버
-    suspend fun postNaverQuit(
-        accessToken: String
-    ): Boolean
+    suspend fun postNaverQuit(): Boolean
 }

--- a/app/src/main/java/com/mongmong/namo/presentation/config/ApplicationClass.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/config/ApplicationClass.kt
@@ -53,7 +53,6 @@ class ApplicationClass: Application() {
         const val X_REFRESH_TOKEN = "X_REFRESH_TOKEN"
 
         const val SDK_PLATFORM = "SDK_PLATFORM"
-        const val SDK_ACCESS_TOKEN = "SDK_ACCESS_TOKEN"
 
         // Retrofit 인스턴스, 앱 실행시 한번만 생성하여 사용합니다.
         val sRetrofit: Retrofit

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/login/AuthViewModel.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/login/AuthViewModel.kt
@@ -8,7 +8,6 @@ import androidx.lifecycle.viewModelScope
 import com.mongmong.namo.domain.model.LoginBody
 import com.mongmong.namo.domain.model.LoginResult
 import com.mongmong.namo.domain.model.RefreshResponse
-import com.mongmong.namo.domain.model.SdkInfo
 import com.mongmong.namo.domain.model.TokenBody
 import com.mongmong.namo.domain.repositories.AuthRepository
 import com.mongmong.namo.presentation.config.ApplicationClass
@@ -43,7 +42,7 @@ class AuthViewModel @Inject constructor(
                 _loginResult.value = repository.postNaverLogin(LoginBody(accessToken, refreshToken)).result
             }
             _loginResult.value?.let {
-                saveLoginSdkInfo(SdkInfo(platform.platformName, accessToken))
+                saveLoginPlatform(platform)
                 // 토큰 저장
                 saveToken(it)
             }
@@ -71,13 +70,13 @@ class AuthViewModel @Inject constructor(
 
     /** 회원탈퇴 */
     fun tryQuit() {
-        val sdkInfo = getLoginSdkInfo()
-        Log.d("SdkInfo", "quit sdk: $sdkInfo")
+        val platform = getLoginPlatform()
+        Log.d("SdkInfo", "quit sdk: $platform")
         viewModelScope.launch {
-            val isSuccess = if (sdkInfo.platform == LoginPlatform.KAKAO.platformName) { // 카카오
-                repository.postKakaoQuit()
+            val isSuccess = if (platform == LoginPlatform.KAKAO.platformName) { // 카카오
+                repository.postKakaoQuit(getBearerToken())
             } else { // 네이버
-                repository.postNaverQuit()
+                repository.postNaverQuit(getBearerToken())
             }
             if (isSuccess) {
                 _isQuitComplete.postValue(true)
@@ -88,6 +87,10 @@ class AuthViewModel @Inject constructor(
     }
 
     /** 토큰 */
+    private fun getBearerToken(): String {
+        return "Bearer ${getAccessToken()}"
+    }
+
     private fun getAccessToken(): String? {
         return ApplicationClass.sSharedPreferences.getString(ApplicationClass.X_ACCESS_TOKEN, null)
     }
@@ -99,16 +102,15 @@ class AuthViewModel @Inject constructor(
     }
 
     // 로그인 한 sdk 정보 가져오기
-    private fun getLoginSdkInfo(): SdkInfo {
+    private fun getLoginPlatform(): String {
         val spf = ApplicationClass.sSharedPreferences
-        return SdkInfo(spf.getString(ApplicationClass.SDK_PLATFORM, LoginPlatform.KAKAO.platformName)!!, spf.getString(ApplicationClass.SDK_ACCESS_TOKEN, "")!!)
+        return spf.getString(ApplicationClass.SDK_PLATFORM, LoginPlatform.KAKAO.platformName)!!
     }
 
     // 로그인 플랫폼 정보 앱 내에 저장
-    private fun saveLoginSdkInfo(sdkInfo: SdkInfo) {
+    private fun saveLoginPlatform(platform: LoginPlatform) {
         ApplicationClass.sSharedPreferences.edit()
-            .putString(ApplicationClass.SDK_PLATFORM, sdkInfo.platform)
-            .putString(ApplicationClass.SDK_ACCESS_TOKEN, sdkInfo.accessToken)
+            .putString(ApplicationClass.SDK_PLATFORM, platform.platformName)
             .apply()
     }
 

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/login/AuthViewModel.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/login/AuthViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.mongmong.namo.domain.model.LoginBody
 import com.mongmong.namo.domain.model.LoginResult
 import com.mongmong.namo.domain.model.RefreshResponse
 import com.mongmong.namo.domain.model.SdkInfo
@@ -33,13 +34,13 @@ class AuthViewModel @Inject constructor(
     val refreshResponse: LiveData<RefreshResponse> = _refreshResponse
 
     /** 로그인 */
-    fun tryLogin(platform: LoginPlatform, accessToken: String) {
-        Log.d("${platform.platformName}Token", accessToken)
+    fun tryLogin(platform: LoginPlatform, accessToken: String, refreshToken: String) {
+        Log.d("${platform.platformName}Token", "accessToken: $accessToken, refreshToken: $refreshToken")
         viewModelScope.launch {
             if (platform == LoginPlatform.KAKAO) {
-                _loginResult.value = repository.postKakaoLogin(accessToken).result
+                _loginResult.value = repository.postKakaoLogin(LoginBody(accessToken, refreshToken)).result
             } else {
-                _loginResult.value = repository.postNaverLogin(accessToken).result
+                _loginResult.value = repository.postNaverLogin(LoginBody(accessToken, refreshToken)).result
             }
             _loginResult.value?.let {
                 saveLoginSdkInfo(SdkInfo(platform.platformName, accessToken))
@@ -74,9 +75,9 @@ class AuthViewModel @Inject constructor(
         Log.d("SdkInfo", "quit sdk: $sdkInfo")
         viewModelScope.launch {
             val isSuccess = if (sdkInfo.platform == LoginPlatform.KAKAO.platformName) { // 카카오
-                repository.postKakaoQuit(sdkInfo.accessToken)
+                repository.postKakaoQuit()
             } else { // 네이버
-                repository.postNaverQuit(sdkInfo.accessToken)
+                repository.postNaverQuit()
             }
             if (isSuccess) {
                 _isQuitComplete.postValue(true)

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/login/LoginFragment.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/login/LoginFragment.kt
@@ -79,8 +79,8 @@ class LoginFragment: Fragment() {
         }
     }
 
-    private fun tryLogin(platform: LoginPlatform, accessToken: String) {
-        viewModel.tryLogin(platform, accessToken)
+    private fun tryLogin(platform: LoginPlatform, accessToken: String, refreshToken: String) {
+        viewModel.tryLogin(platform, accessToken, refreshToken)
     }
 
     private fun startKakaoLogin() {
@@ -95,7 +95,7 @@ class LoginFragment: Fragment() {
             } else if (token != null) {
                 Log.i(ContentValues.TAG, "카카오계정으로 로그인 성공 ${token.accessToken}")
 
-                tryLogin(LoginPlatform.KAKAO, token.accessToken)
+                tryLogin(LoginPlatform.KAKAO, token.accessToken, token.refreshToken)
             }
         }
         // 카카오톡이 설치되어 있으면 카카오톡으로 로그인, 아니면 카카오계정으로 로그인
@@ -109,7 +109,7 @@ class LoginFragment: Fragment() {
     private fun loginWithKakaoAccount() {
         val callback: (OAuthToken?, Throwable?) -> Unit = { token, error ->
             if (token != null) {
-                tryLogin(LoginPlatform.KAKAO, token.accessToken)
+                tryLogin(LoginPlatform.KAKAO, token.accessToken, token.refreshToken)
             }
         }
         UserApiClient.instance.loginWithKakaoAccount(requireContext(), callback = callback)
@@ -119,13 +119,13 @@ class LoginFragment: Fragment() {
         // OAuthLoginCallback을 authenticate() 메서드 호출 시 파라미터로 전달하거나 NidOAuthLoginButton 객체에 등록하면 인증이 종료됨
         val oauthLoginCallback = object : OAuthLoginCallback {
             override fun onSuccess() {
-                tryLogin(LoginPlatform.NAVER, NaverIdLoginSDK.getAccessToken().toString())
+                tryLogin(LoginPlatform.NAVER, NaverIdLoginSDK.getAccessToken().toString(), NaverIdLoginSDK.getRefreshToken().toString())
             }
 
             override fun onFailure(httpStatus: Int, message: String) {
                 val errorCode = NaverIdLoginSDK.getLastErrorCode().code
                 val errorDescription = NaverIdLoginSDK.getLastErrorDescription()
-//                Toast.makeText(requireActivity(), "errorCode: $errorCode, errorDesc: $errorDescription", Toast.LENGTH_SHORT).show()
+                Log.d("naverLogin", "errorCode: $errorCode, errorDesc: $errorDescription")
             }
 
             override fun onError(errorCode: Int, message: String) {


### PR DESCRIPTION
## Related Issue
- #225 

## Type of change
<!-- 작업의 종류를 선택해주세요. -->
- [x] Feature : 새로운 기능 추가
- [x] Bug fix : 버그 수정
- [ ] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [ ] Style : 코드 스타일 및 포맷팅 작업
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## PR Description
> 변경 사항 설명

- 기존에는 회원탈퇴 시 소셜 액세스 토큰을 함께 보냈는데, 로그인 시 소셜 액세스와 리프레시를 함께 보내 서버에 저장된 소셜 토큰으로 회원탈퇴가 되도록 로직이 변경되었습니다.
- 이에 따라 기존에 소셜 액세스를 sharedPreferences에서 저장해놓던 코드를 삭제했습니다.

## Requirements for Reviewer
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

현재 ServiceModule에서 인증 관련 AuthApiService가 인터셉터가 없는 BaseRetrofit을 주입받고 있습니다.
인증 관련 API 중에서 로그인은 헤더가 없어도 되고, 회원탈퇴는 헤더가 필요합니다. (토큰 재발급, 로그아웃은 어차피 body로 토큰을 한 번 더 보내고 있음)
그래서 우선 회원탈퇴만 InterceptorRetrofit을 쓰는 방식 말고, 따로 헤더를 직접 넣어주고 있는데 더 좋은 방법이 있을까요?

## PR Log

> PR 작업하면서 고민했던 내용, 해결한 내용, 고민 중인 내용 등

### 새롭게 배운 것

- 

### 고민 중인 사항

- 

## 첨부 자료

-
