### PR TITLE
[Fix/235] 캘린더 이모지 대응, 캘린더 말줄임표 삭제

### DIFF
--- a/app/src/main/java/com/mongmong/namo/presentation/ui/group/calendar/GroupCalendarView.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/group/calendar/GroupCalendarView.kt
@@ -6,6 +6,7 @@ import android.text.TextUtils
 import android.util.AttributeSet
 import com.mongmong.namo.domain.model.group.MoimScheduleBody
 import com.mongmong.namo.presentation.config.CategoryColor
+import com.mongmong.namo.presentation.ui.home.calendar.data.StartEnd
 import com.mongmong.namo.presentation.utils.CalendarUtils.Companion.DAYS_PER_WEEK
 import com.mongmong.namo.presentation.utils.CustomCalendarView
 import org.joda.time.DateTime
@@ -16,103 +17,117 @@ class GroupCalendarView(context: Context, attrs: AttributeSet) :
 
     override fun drawSchedules(canvas: Canvas) {
         if (cellHeight - eventTop > _eventHeight * 4) {
-            for (i in 0 until scheduleList.size) {
-                val startIdx = days.indexOf(DateTime(scheduleList[i].startDate * 1000L).withTimeAtStartOfDay())
-                val endIdx = days.indexOf(DateTime(scheduleList[i].endDate * 1000L).withTimeAtStartOfDay())
-
-                for (splitSchedule in splitWeek(startIdx, endIdx)) {
-                    val order = findMaxOrderInSchedule(splitSchedule.startIdx, splitSchedule.endIdx)
-                    setOrder(order, splitSchedule.startIdx, splitSchedule.endIdx)
-
-                    if (cellHeight - getScheduleBottom(order) < _eventHeight) {
-                        for (idx in splitSchedule.startIdx..splitSchedule.endIdx) {
-                            moreList[idx] = moreList[idx] + 1
-                        }
-                        continue
-                    }
-
-                    rect = setRect(order, splitSchedule.startIdx, splitSchedule.endIdx)
-                    val path = Path()
-                    path.addRoundRect(rect, corners, Path.Direction.CW)
-                    setBgPaintColor(scheduleList[i])
-                    canvas.drawPath(path, bgPaint)
-
-                    // 텍스트 너비 계산 및 경로 너비 초과 시 텍스트 잘라내기
-                    val textWidth = eventPaint.measureText(scheduleList[i].name) + (2 * _eventHorizontalPadding)
-                    val pathWidth = rect.width()
-                    val textToDraw = if (textWidth > pathWidth) {
-                        val availableWidth = pathWidth - (2 * _eventHorizontalPadding)
-                        val truncatedLength = eventPaint.breakText(scheduleList[i].name, true, availableWidth, null)
-                        scheduleList[i].name.substring(0, truncatedLength)
-                    } else {
-                        scheduleList[i].name
-                    }
-
-                    eventPaint.getTextBounds(textToDraw, 0, textToDraw.length, eventBounds)
-
-                    // 이모지와 일반 텍스트 모두에 대해 텍스트 높이를 계산하여 중앙 정렬
-                    val textHeight = eventBounds.height().toFloat()
-                    val textBottom = (rect.top + rect.bottom) / 2 + textHeight / 2 - eventBounds.bottom
-
-                    // 텍스트가 블록 중앙에 오도록 위치 조정
-                    canvas.drawText(
-                        textToDraw,
-                        getScheduleTextStart(splitSchedule.startIdx),
-                        textBottom,
-                        eventPaint
-                    )
-                }
-            }
-
-            for (more in 0 until 42) {
-                if (moreList[more] != 0) {
-                    val moreText: String = "+${moreList[more]}"
-
-                    val x = (more % DAYS_PER_WEEK) * cellWidth
-                    val y = (more / DAYS_PER_WEEK + 1) * cellHeight - _eventMorePadding
-
-                    morePaint.getTextBounds(moreText, 0, moreText.length, moreBounds)
-                    canvas.drawText(
-                        moreText,
-                        (x + cellWidth / 2 - moreBounds.right.toFloat() / 2),
-                        y,
-                        morePaint
-                    )
-                }
-            }
+            drawDetailedSchedules(canvas)
         } else {
-            for (i in 0 until scheduleList.size) {
-                val startIdx = days.indexOf(DateTime(scheduleList[i].startDate * 1000L).withTimeAtStartOfDay())
-                val endIdx = days.indexOf(DateTime(scheduleList[i].endDate * 1000L).withTimeAtStartOfDay())
+            drawCompactSchedules(canvas)
+        }
 
-                for (splitSchedule in splitWeek(startIdx, endIdx)) {
-                    val order = findMaxOrderInSchedule(splitSchedule.startIdx, splitSchedule.endIdx)
-                    setOrder(order, splitSchedule.startIdx, splitSchedule.endIdx)
+        drawMoreText(canvas)
+    }
 
-                    if (getScheduleLineBottom(order) >= cellHeight) {
-                        continue
-                    }
+    private fun drawDetailedSchedules(canvas: Canvas) {
+        for (i in scheduleList.indices) {
+            val startIdx = days.indexOf(DateTime(scheduleList[i].startDate * 1000L).withTimeAtStartOfDay())
+            val endIdx = days.indexOf(DateTime(scheduleList[i].endDate * 1000L).withTimeAtStartOfDay())
 
-                    rect = setLineRect(order, splitSchedule.startIdx, splitSchedule.endIdx)
-                    val path = Path()
-                    path.addRoundRect(rect, corners, Path.Direction.CW)
-                    setBgPaintColor(scheduleList[i])
-                    canvas.drawPath(path, bgPaint)
+            for (splitSchedule in splitWeek(startIdx, endIdx)) {
+                val order = findMaxOrderInSchedule(splitSchedule.startIdx, splitSchedule.endIdx)
+                setOrder(order, splitSchedule.startIdx, splitSchedule.endIdx)
+
+                if (cellHeight - getScheduleBottom(order) < _eventHeight) {
+                    incrementMoreList(splitSchedule)
+                    continue
                 }
+
+                drawScheduleRect(canvas, scheduleList[i], order, splitSchedule)
             }
         }
     }
 
-    private fun setBgPaintColor(event: MoimScheduleBody) {
-        //  Log.d("BG_COLOR", event.toString())
-        val paletteId = if (event.curMoimSchedule) 4
-//                        else {
-//                            if (event.users.size < 2 && event.users[0].color != 0) event.users[0].color
-//                            else 3
-//                        }
-        else event.users[0].color
-        //    Log.d("GroupCalView", "유저 : ${event.users} | paletteId : ${paletteId}")
-        bgPaint.color = Color.parseColor(CategoryColor.getAllColors()[paletteId - 1])
+    private fun drawCompactSchedules(canvas: Canvas) {
+        for (i in scheduleList.indices) {
+            val startIdx = days.indexOf(DateTime(scheduleList[i].startDate * 1000L).withTimeAtStartOfDay())
+            val endIdx = days.indexOf(DateTime(scheduleList[i].endDate * 1000L).withTimeAtStartOfDay())
+
+            for (splitSchedule in splitWeek(startIdx, endIdx)) {
+                val order = findMaxOrderInSchedule(splitSchedule.startIdx, splitSchedule.endIdx)
+                setOrder(order, splitSchedule.startIdx, splitSchedule.endIdx)
+
+                if (getScheduleLineBottom(order) >= cellHeight) {
+                    continue
+                }
+
+                drawScheduleLine(canvas, scheduleList[i], order, splitSchedule)
+            }
+        }
+    }
+
+    private fun drawScheduleRect(canvas: Canvas, schedule: MoimScheduleBody, order: Int, splitSchedule: StartEnd) {
+        rect = setRect(order, splitSchedule.startIdx, splitSchedule.endIdx)
+        val path = Path().apply {
+            addRoundRect(rect, corners, Path.Direction.CW)
+        }
+        setBgPaintColor(schedule)
+        canvas.drawPath(path, bgPaint)
+
+        val textToDraw = getTruncatedText(schedule.name, rect.width())
+        drawScheduleText(canvas, textToDraw, splitSchedule.startIdx, rect)
+    }
+
+    private fun drawScheduleLine(canvas: Canvas, schedule: MoimScheduleBody, order: Int, splitSchedule: StartEnd) {
+        rect = setLineRect(order, splitSchedule.startIdx, splitSchedule.endIdx)
+        val path = Path().apply {
+            addRoundRect(rect, corners, Path.Direction.CW)
+        }
+        setBgPaintColor(schedule)
+        canvas.drawPath(path, bgPaint)
+    }
+
+    private fun incrementMoreList(splitSchedule: StartEnd) {
+        for (idx in splitSchedule.startIdx..splitSchedule.endIdx) {
+            moreList[idx] += 1
+        }
+    }
+
+    private fun drawMoreText(canvas: Canvas) {
+        for (more in 0 until 42) {
+            if (moreList[more] != 0) {
+                val moreText = "+${moreList[more]}"
+                val x = (more % DAYS_PER_WEEK) * cellWidth
+                val y = (more / DAYS_PER_WEEK + 1) * cellHeight - _eventMorePadding
+
+                morePaint.getTextBounds(moreText, 0, moreText.length, moreBounds)
+                canvas.drawText(
+                    moreText,
+                    (x + cellWidth / 2 - moreBounds.right.toFloat() / 2),
+                    y,
+                    morePaint
+                )
+            }
+        }
+    }
+
+    private fun getTruncatedText(text: String, availableWidth: Float): String {
+        val textWidth = eventPaint.measureText(text) + (2 * _eventHorizontalPadding)
+        return if (textWidth > availableWidth) {
+            val limitLength = eventPaint.breakText(text, true, availableWidth - (2 * _eventHorizontalPadding), null)
+            text.substring(0, limitLength)
+        } else {
+            text
+        }
+    }
+
+    private fun drawScheduleText(canvas: Canvas, text: String, startIdx: Int, rect: RectF) {
+        eventPaint.getTextBounds(text, 0, text.length, eventBounds)
+        val textHeight = eventBounds.height().toFloat()
+        val textBottom = (rect.top + rect.bottom) / 2 + textHeight / 2 - eventBounds.bottom
+
+        canvas.drawText(
+            text,
+            getScheduleTextStart(startIdx),
+            textBottom,
+            eventPaint
+        )
     }
 
     fun setScheduleList(events: List<MoimScheduleBody>) {
@@ -126,5 +141,10 @@ class GroupCalendarView(context: Context, attrs: AttributeSet) :
         scheduleList.addAll(sortedEvents)
 
         invalidate()
+    }
+
+    private fun setBgPaintColor(event: MoimScheduleBody) {
+        val paletteId = if (event.curMoimSchedule) 4 else event.users[0].color
+        bgPaint.color = Color.parseColor(CategoryColor.getAllColors()[paletteId - 1])
     }
 }

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/group/calendar/GroupCalendarView.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/group/calendar/GroupCalendarView.kt
@@ -17,11 +17,8 @@ class GroupCalendarView(context: Context, attrs: AttributeSet) :
     override fun drawSchedules(canvas: Canvas) {
         if (cellHeight - eventTop > _eventHeight * 4) {
             for (i in 0 until scheduleList.size) {
-//                x계산하고, y계산하기
-                val startIdx =
-                    days.indexOf(DateTime(scheduleList[i].startDate * 1000L).withTimeAtStartOfDay())
-                val endIdx =
-                    days.indexOf(DateTime(scheduleList[i].endDate * 1000L).withTimeAtStartOfDay())
+                val startIdx = days.indexOf(DateTime(scheduleList[i].startDate * 1000L).withTimeAtStartOfDay())
+                val endIdx = days.indexOf(DateTime(scheduleList[i].endDate * 1000L).withTimeAtStartOfDay())
 
                 for (splitSchedule in splitWeek(startIdx, endIdx)) {
                     val order = findMaxOrderInSchedule(splitSchedule.startIdx, splitSchedule.endIdx)
@@ -38,71 +35,44 @@ class GroupCalendarView(context: Context, attrs: AttributeSet) :
                     val path = Path()
                     path.addRoundRect(rect, corners, Path.Direction.CW)
                     setBgPaintColor(scheduleList[i])
-                    canvas!!.drawPath(path, bgPaint)
+                    canvas.drawPath(path, bgPaint)
 
-                    val textWidth =
-                        eventPaint.measureText(scheduleList[i].name) + (2 * _eventHorizontalPadding)
+                    // 텍스트 너비 계산 및 경로 너비 초과 시 텍스트 잘라내기
+                    val textWidth = eventPaint.measureText(scheduleList[i].name) + (2 * _eventHorizontalPadding)
                     val pathWidth = rect.width()
-
-                    if (textWidth > pathWidth) {
-                        val ellipsizedText = TextUtils.ellipsize(
-                            scheduleList[i].name,
-                            eventPaint,
-                            pathWidth - (2 * _eventHorizontalPadding),
-                            TextUtils.TruncateAt.END
-                        )
-
-                        eventPaint.getTextBounds(
-                            ellipsizedText.toString(),
-                            0,
-                            ellipsizedText.toString().length,
-                            eventBounds
-                        )
-
-                        canvas.drawText(
-                            ellipsizedText.toString(),
-                            getScheduleTextStart(splitSchedule.startIdx),
-                            getScheduleTextBottom(
-                                ellipsizedText.toString(),
-                                splitSchedule.startIdx,
-                                splitSchedule.endIdx,
-                                order
-                            ),
-                            eventPaint
-                        )
-
+                    val textToDraw = if (textWidth > pathWidth) {
+                        val availableWidth = pathWidth - (2 * _eventHorizontalPadding)
+                        val truncatedLength = eventPaint.breakText(scheduleList[i].name, true, availableWidth, null)
+                        scheduleList[i].name.substring(0, truncatedLength)
                     } else {
-                        eventPaint.getTextBounds(
-                            scheduleList[i].name,
-                            0,
-                            scheduleList[i].name.length,
-                            eventBounds
-                        )
-
-                        canvas.drawText(
-                            scheduleList[i].name,
-                            getScheduleTextStart(splitSchedule.startIdx),
-                            getScheduleTextBottom(
-                                scheduleList[i].name,
-                                splitSchedule.startIdx,
-                                splitSchedule.endIdx,
-                                order
-                            ),
-                            eventPaint
-                        )
+                        scheduleList[i].name
                     }
+
+                    eventPaint.getTextBounds(textToDraw, 0, textToDraw.length, eventBounds)
+
+                    // 이모지와 일반 텍스트 모두에 대해 텍스트 높이를 계산하여 중앙 정렬
+                    val textHeight = eventBounds.height().toFloat()
+                    val textBottom = (rect.top + rect.bottom) / 2 + textHeight / 2 - eventBounds.bottom
+
+                    // 텍스트가 블록 중앙에 오도록 위치 조정
+                    canvas.drawText(
+                        textToDraw,
+                        getScheduleTextStart(splitSchedule.startIdx),
+                        textBottom,
+                        eventPaint
+                    )
                 }
             }
 
             for (more in 0 until 42) {
                 if (moreList[more] != 0) {
-                    var moreText: String = "+${moreList[more]}"
+                    val moreText: String = "+${moreList[more]}"
 
                     val x = (more % DAYS_PER_WEEK) * cellWidth
                     val y = (more / DAYS_PER_WEEK + 1) * cellHeight - _eventMorePadding
 
                     morePaint.getTextBounds(moreText, 0, moreText.length, moreBounds)
-                    canvas!!.drawText(
+                    canvas.drawText(
                         moreText,
                         (x + cellWidth / 2 - moreBounds.right.toFloat() / 2),
                         y,
@@ -112,11 +82,8 @@ class GroupCalendarView(context: Context, attrs: AttributeSet) :
             }
         } else {
             for (i in 0 until scheduleList.size) {
-//                x계산하고, y계산하기
-                val startIdx =
-                    days.indexOf(DateTime(scheduleList[i].startDate * 1000L).withTimeAtStartOfDay())
-                val endIdx =
-                    days.indexOf(DateTime(scheduleList[i].endDate * 1000L).withTimeAtStartOfDay())
+                val startIdx = days.indexOf(DateTime(scheduleList[i].startDate * 1000L).withTimeAtStartOfDay())
+                val endIdx = days.indexOf(DateTime(scheduleList[i].endDate * 1000L).withTimeAtStartOfDay())
 
                 for (splitSchedule in splitWeek(startIdx, endIdx)) {
                     val order = findMaxOrderInSchedule(splitSchedule.startIdx, splitSchedule.endIdx)
@@ -130,7 +97,7 @@ class GroupCalendarView(context: Context, attrs: AttributeSet) :
                     val path = Path()
                     path.addRoundRect(rect, corners, Path.Direction.CW)
                     setBgPaintColor(scheduleList[i])
-                    canvas!!.drawPath(path, bgPaint)
+                    canvas.drawPath(path, bgPaint)
                 }
             }
         }

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/home/calendar/PersonalCalendarView.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/home/calendar/PersonalCalendarView.kt
@@ -19,11 +19,8 @@ class PersonalCalendarView(context: Context, attrs: AttributeSet) :
     override fun drawSchedules(canvas: Canvas) {
         if (cellHeight - eventTop > _eventHeight * 3) {
             for (i in 0 until scheduleList.size) {
-//                x계산하고, y계산하기
-                val startIdx =
-                    days.indexOf(DateTime(scheduleList[i].startLong * 1000L).withTimeAtStartOfDay())
-                val endIdx =
-                    days.indexOf(DateTime(scheduleList[i].endLong * 1000L).withTimeAtStartOfDay())
+                val startIdx = days.indexOf(DateTime(scheduleList[i].startLong * 1000L).withTimeAtStartOfDay())
+                val endIdx = days.indexOf(DateTime(scheduleList[i].endLong * 1000L).withTimeAtStartOfDay())
 
                 for (splitSchedule in splitWeek(startIdx, endIdx)) {
                     val order = findMaxOrderInSchedule(splitSchedule.startIdx, splitSchedule.endIdx)
@@ -40,71 +37,44 @@ class PersonalCalendarView(context: Context, attrs: AttributeSet) :
                     val path = Path()
                     path.addRoundRect(rect, corners, Path.Direction.CW)
                     setBgPaintColor(scheduleList[i])
-                    canvas!!.drawPath(path, bgPaint)
+                    canvas.drawPath(path, bgPaint)
 
-                    val textWidth =
-                        eventPaint.measureText(scheduleList[i].title) + (2 * _eventHorizontalPadding)
+                    // 텍스트 너비 계산 및 초과 시 텍스트 잘라내기
+                    val textWidth = eventPaint.measureText(scheduleList[i].title) + (2 * _eventHorizontalPadding)
                     val pathWidth = rect.width()
-
-                    if (textWidth > pathWidth) {
-                        val ellipsizedText = TextUtils.ellipsize(
-                            scheduleList[i].title,
-                            eventPaint,
-                            pathWidth - (2 * _eventHorizontalPadding),
-                            TextUtils.TruncateAt.END
-                        )
-
-                        eventPaint.getTextBounds(
-                            ellipsizedText.toString(),
-                            0,
-                            ellipsizedText.toString().length,
-                            eventBounds
-                        )
-
-                        canvas.drawText(
-                            ellipsizedText.toString(),
-                            getScheduleTextStart(splitSchedule.startIdx),
-                            getScheduleTextBottom(
-                                ellipsizedText.toString(),
-                                splitSchedule.startIdx,
-                                splitSchedule.endIdx,
-                                order
-                            ),
-                            eventPaint
-                        )
-
+                    val textToDraw = if (textWidth > pathWidth) {
+                        val availableWidth = pathWidth - (2 * _eventHorizontalPadding)
+                        val limitLength = eventPaint.breakText(scheduleList[i].title, true, availableWidth, null)
+                        scheduleList[i].title.substring(0, limitLength)
                     } else {
-                        eventPaint.getTextBounds(
-                            scheduleList[i].title,
-                            0,
-                            scheduleList[i].title.length,
-                            eventBounds
-                        )
-
-                        canvas.drawText(
-                            scheduleList[i].title,
-                            getScheduleTextStart(splitSchedule.startIdx),
-                            getScheduleTextBottom(
-                                scheduleList[i].title,
-                                splitSchedule.startIdx,
-                                splitSchedule.endIdx,
-                                order
-                            ),
-                            eventPaint
-                        )
+                        scheduleList[i].title
                     }
+
+                    eventPaint.getTextBounds(textToDraw, 0, textToDraw.length, eventBounds)
+
+                    // 이모지와 일반 텍스트 모두에 대해 텍스트 높이를 계산하여 중앙 정렬
+                    val textHeight = eventBounds.height().toFloat()
+                    val textBottom = (rect.top + rect.bottom) / 2 + textHeight / 2 - eventBounds.bottom
+
+                    // 텍스트가 블록 중앙에 오도록 위치 조정
+                    canvas.drawText(
+                        textToDraw,
+                        getScheduleTextStart(splitSchedule.startIdx),
+                        textBottom,
+                        eventPaint
+                    )
                 }
             }
 
             for (more in 0 until 42) {
                 if (moreList[more] != 0) {
-                    var moreText = "+${moreList[more]}"
+                    val moreText = "+${moreList[more]}"
 
                     val x = (more % DAYS_PER_WEEK) * cellWidth
                     val y = (more / DAYS_PER_WEEK + 1) * cellHeight - _eventMorePadding
 
                     morePaint.getTextBounds(moreText, 0, moreText.length, moreBounds)
-                    canvas!!.drawText(
+                    canvas.drawText(
                         moreText,
                         (x + cellWidth / 2 - moreBounds.right.toFloat() / 2),
                         y,
@@ -114,11 +84,8 @@ class PersonalCalendarView(context: Context, attrs: AttributeSet) :
             }
         } else {
             for (i in 0 until scheduleList.size) {
-//                x계산하고, y계산하기
-                val startIdx =
-                    days.indexOf(DateTime(scheduleList[i].startLong * 1000L).withTimeAtStartOfDay())
-                val endIdx =
-                    days.indexOf(DateTime(scheduleList[i].endLong * 1000L).withTimeAtStartOfDay())
+                val startIdx = days.indexOf(DateTime(scheduleList[i].startLong * 1000L).withTimeAtStartOfDay())
+                val endIdx = days.indexOf(DateTime(scheduleList[i].endLong * 1000L).withTimeAtStartOfDay())
 
                 for (splitSchedule in splitWeek(startIdx, endIdx)) {
                     val order = findMaxOrderInSchedule(splitSchedule.startIdx, splitSchedule.endIdx)
@@ -132,11 +99,14 @@ class PersonalCalendarView(context: Context, attrs: AttributeSet) :
                     val path = Path()
                     path.addRoundRect(rect, corners, Path.Direction.CW)
                     setBgPaintColor(scheduleList[i])
-                    canvas!!.drawPath(path, bgPaint)
+                    canvas.drawPath(path, bgPaint)
                 }
             }
         }
     }
+
+
+
 
     fun setScheduleList(events: List<Schedule>) {
         val sortedEvents = events.sortedWith(compareByDescending<Schedule> {
@@ -158,9 +128,6 @@ class PersonalCalendarView(context: Context, attrs: AttributeSet) :
     }
 
     private fun setBgPaintColor(event: Schedule) {
-        //Log.d("BG_COLOR_CHECK", categoryList.toString())
-        //Log.d("BG_COLOR_CHECK", event.toString())
-        //Log.d("BG_COLOR_CHECK", "Category Server : " + event.categoryServerId + " | Category Idx : " + event.categoryId)
         val foundCategory = categoryList.find {
             if (it.serverId != 0L) it.serverId == event.categoryServerId
             else it.categoryId == event.categoryId

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/home/calendar/PersonalCalendarView.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/home/calendar/PersonalCalendarView.kt
@@ -7,6 +7,7 @@ import android.util.AttributeSet
 import com.mongmong.namo.data.local.entity.home.Category
 import com.mongmong.namo.data.local.entity.home.Schedule
 import com.mongmong.namo.presentation.config.CategoryColor
+import com.mongmong.namo.presentation.ui.home.calendar.data.StartEnd
 import com.mongmong.namo.presentation.utils.CalendarUtils.Companion.DAYS_PER_WEEK
 import com.mongmong.namo.presentation.utils.CustomCalendarView
 import org.joda.time.DateTime
@@ -18,95 +19,118 @@ class PersonalCalendarView(context: Context, attrs: AttributeSet) :
 
     override fun drawSchedules(canvas: Canvas) {
         if (cellHeight - eventTop > _eventHeight * 3) {
-            for (i in 0 until scheduleList.size) {
-                val startIdx = days.indexOf(DateTime(scheduleList[i].startLong * 1000L).withTimeAtStartOfDay())
-                val endIdx = days.indexOf(DateTime(scheduleList[i].endLong * 1000L).withTimeAtStartOfDay())
-
-                for (splitSchedule in splitWeek(startIdx, endIdx)) {
-                    val order = findMaxOrderInSchedule(splitSchedule.startIdx, splitSchedule.endIdx)
-                    setOrder(order, splitSchedule.startIdx, splitSchedule.endIdx)
-
-                    if (cellHeight - getScheduleBottom(order) < _eventHeight) {
-                        for (idx in splitSchedule.startIdx..splitSchedule.endIdx) {
-                            moreList[idx] = moreList[idx] + 1
-                        }
-                        continue
-                    }
-
-                    rect = setRect(order, splitSchedule.startIdx, splitSchedule.endIdx)
-                    val path = Path()
-                    path.addRoundRect(rect, corners, Path.Direction.CW)
-                    setBgPaintColor(scheduleList[i])
-                    canvas.drawPath(path, bgPaint)
-
-                    // 텍스트 너비 계산 및 초과 시 텍스트 잘라내기
-                    val textWidth = eventPaint.measureText(scheduleList[i].title) + (2 * _eventHorizontalPadding)
-                    val pathWidth = rect.width()
-                    val textToDraw = if (textWidth > pathWidth) {
-                        val availableWidth = pathWidth - (2 * _eventHorizontalPadding)
-                        val limitLength = eventPaint.breakText(scheduleList[i].title, true, availableWidth, null)
-                        scheduleList[i].title.substring(0, limitLength)
-                    } else {
-                        scheduleList[i].title
-                    }
-
-                    eventPaint.getTextBounds(textToDraw, 0, textToDraw.length, eventBounds)
-
-                    // 이모지와 일반 텍스트 모두에 대해 텍스트 높이를 계산하여 중앙 정렬
-                    val textHeight = eventBounds.height().toFloat()
-                    val textBottom = (rect.top + rect.bottom) / 2 + textHeight / 2 - eventBounds.bottom
-
-                    // 텍스트가 블록 중앙에 오도록 위치 조정
-                    canvas.drawText(
-                        textToDraw,
-                        getScheduleTextStart(splitSchedule.startIdx),
-                        textBottom,
-                        eventPaint
-                    )
-                }
-            }
-
-            for (more in 0 until 42) {
-                if (moreList[more] != 0) {
-                    val moreText = "+${moreList[more]}"
-
-                    val x = (more % DAYS_PER_WEEK) * cellWidth
-                    val y = (more / DAYS_PER_WEEK + 1) * cellHeight - _eventMorePadding
-
-                    morePaint.getTextBounds(moreText, 0, moreText.length, moreBounds)
-                    canvas.drawText(
-                        moreText,
-                        (x + cellWidth / 2 - moreBounds.right.toFloat() / 2),
-                        y,
-                        morePaint
-                    )
-                }
-            }
+            drawDetailedSchedules(canvas)
         } else {
-            for (i in 0 until scheduleList.size) {
-                val startIdx = days.indexOf(DateTime(scheduleList[i].startLong * 1000L).withTimeAtStartOfDay())
-                val endIdx = days.indexOf(DateTime(scheduleList[i].endLong * 1000L).withTimeAtStartOfDay())
+            drawCompactSchedules(canvas)
+        }
 
-                for (splitSchedule in splitWeek(startIdx, endIdx)) {
-                    val order = findMaxOrderInSchedule(splitSchedule.startIdx, splitSchedule.endIdx)
-                    setOrder(order, splitSchedule.startIdx, splitSchedule.endIdx)
+        drawMoreText(canvas)
+    }
 
-                    if (getScheduleLineBottom(order) >= cellHeight) {
-                        continue
-                    }
+    private fun drawDetailedSchedules(canvas: Canvas) {
+        for (i in scheduleList.indices) {
+            val startIdx = days.indexOf(DateTime(scheduleList[i].startLong * 1000L).withTimeAtStartOfDay())
+            val endIdx = days.indexOf(DateTime(scheduleList[i].endLong * 1000L).withTimeAtStartOfDay())
 
-                    rect = setLineRect(order, splitSchedule.startIdx, splitSchedule.endIdx)
-                    val path = Path()
-                    path.addRoundRect(rect, corners, Path.Direction.CW)
-                    setBgPaintColor(scheduleList[i])
-                    canvas.drawPath(path, bgPaint)
+            for (splitSchedule in splitWeek(startIdx, endIdx)) {
+                val order = findMaxOrderInSchedule(splitSchedule.startIdx, splitSchedule.endIdx)
+                setOrder(order, splitSchedule.startIdx, splitSchedule.endIdx)
+
+                if (cellHeight - getScheduleBottom(order) < _eventHeight) {
+                    incrementMoreList(splitSchedule)
+                    continue
                 }
+
+                drawScheduleRect(canvas, scheduleList[i], order, splitSchedule)
             }
         }
     }
 
+    private fun drawCompactSchedules(canvas: Canvas) {
+        for (i in scheduleList.indices) {
+            val startIdx = days.indexOf(DateTime(scheduleList[i].startLong * 1000L).withTimeAtStartOfDay())
+            val endIdx = days.indexOf(DateTime(scheduleList[i].endLong * 1000L).withTimeAtStartOfDay())
 
+            for (splitSchedule in splitWeek(startIdx, endIdx)) {
+                val order = findMaxOrderInSchedule(splitSchedule.startIdx, splitSchedule.endIdx)
+                setOrder(order, splitSchedule.startIdx, splitSchedule.endIdx)
 
+                if (getScheduleLineBottom(order) >= cellHeight) {
+                    continue
+                }
+
+                drawScheduleLine(canvas, scheduleList[i], order, splitSchedule)
+            }
+        }
+    }
+
+    private fun drawScheduleRect(canvas: Canvas, schedule: Schedule, order: Int, splitSchedule: StartEnd) {
+        rect = setRect(order, splitSchedule.startIdx, splitSchedule.endIdx)
+        val path = Path().apply {
+            addRoundRect(rect, corners, Path.Direction.CW)
+        }
+        setBgPaintColor(schedule)
+        canvas.drawPath(path, bgPaint)
+
+        val textToDraw = getTruncatedText(schedule.title, rect.width())
+        drawScheduleText(canvas, textToDraw, splitSchedule.startIdx, rect)
+    }
+
+    private fun drawScheduleLine(canvas: Canvas, schedule: Schedule, order: Int, splitSchedule: StartEnd) {
+        rect = setLineRect(order, splitSchedule.startIdx, splitSchedule.endIdx)
+        val path = Path().apply {
+            addRoundRect(rect, corners, Path.Direction.CW)
+        }
+        setBgPaintColor(schedule)
+        canvas.drawPath(path, bgPaint)
+    }
+
+    private fun incrementMoreList(splitSchedule: StartEnd) {
+        for (idx in splitSchedule.startIdx..splitSchedule.endIdx) {
+            moreList[idx] += 1
+        }
+    }
+
+    private fun drawMoreText(canvas: Canvas) {
+        for (more in 0 until 42) {
+            if (moreList[more] != 0) {
+                val moreText = "+${moreList[more]}"
+                val x = (more % DAYS_PER_WEEK) * cellWidth
+                val y = (more / DAYS_PER_WEEK + 1) * cellHeight - _eventMorePadding
+
+                morePaint.getTextBounds(moreText, 0, moreText.length, moreBounds)
+                canvas.drawText(
+                    moreText,
+                    (x + cellWidth / 2 - moreBounds.right.toFloat() / 2),
+                    y,
+                    morePaint
+                )
+            }
+        }
+    }
+
+    private fun getTruncatedText(text: String, availableWidth: Float): String {
+        val textWidth = eventPaint.measureText(text) + (2 * _eventHorizontalPadding)
+        return if (textWidth > availableWidth) {
+            val limitLength = eventPaint.breakText(text, true, availableWidth - (2 * _eventHorizontalPadding), null)
+            text.substring(0, limitLength)
+        } else {
+            text
+        }
+    }
+
+    private fun drawScheduleText(canvas: Canvas, text: String, startIdx: Int, rect: RectF) {
+        eventPaint.getTextBounds(text, 0, text.length, eventBounds)
+        val textHeight = eventBounds.height().toFloat()
+        val textBottom = (rect.top + rect.bottom) / 2 + textHeight / 2 - eventBounds.bottom
+
+        canvas.drawText(
+            text,
+            getScheduleTextStart(startIdx),
+            textBottom,
+            eventPaint
+        )
+    }
 
     fun setScheduleList(events: List<Schedule>) {
         val sortedEvents = events.sortedWith(compareByDescending<Schedule> {
@@ -120,7 +144,6 @@ class PersonalCalendarView(context: Context, attrs: AttributeSet) :
 
         invalidate()
     }
-
 
     fun setCategoryList(category: List<Category>) {
         categoryList.clear()

--- a/app/src/main/java/com/mongmong/namo/presentation/utils/CustomCalendarView.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/utils/CustomCalendarView.kt
@@ -25,41 +25,41 @@ abstract class CustomCalendarView(context: Context, attrs: AttributeSet) : View(
     var onDateClickListener: OnDateClickListener? = null
     var selectedDate: DateTime? = null
     var millis: Long = 0
-    var startX = 0f
-    var startY = 0f
-    var endX = 0f
-    var endY = 0f
-    var isScroll = false
+    private var startX = 0f
+    private var startY = 0f
+    private var endX = 0f
+    private var endY = 0f
+    private var isScroll = false
 
     var cellWidth = 0f
     var cellHeight = 0f
-    val bounds = Rect()
-    val today = DateTime.now().withTimeAtStartOfDay().millis
+    private val bounds = Rect()
+    private val today = DateTime.now().withTimeAtStartOfDay().millis
 
     val days = mutableListOf<DateTime>()
     val categoryList = mutableListOf<Category>()
-    val orderList = mutableListOf<Int>()
+    private val orderList = mutableListOf<Int>()
     val moreList = mutableListOf<Int>()
-    val otherRect: ArrayList<RectF> = arrayListOf()
+    private val otherRect: ArrayList<RectF> = arrayListOf()
 
-    val bounds2 = Rect()
+    private val bounds2 = Rect()
     val eventBounds = Rect()
     val moreBounds = Rect()
     var showTitle: Boolean = false
-    var cellPaint: Paint = Paint()
-    var alphaPaint: Paint = Paint()
-    var datePaint: Paint = Paint()
-    var todayPaint: Paint = Paint()
-    var selectedPaint: Paint = Paint()
-    var clickPaint: Paint = Paint()
+    private var cellPaint: Paint = Paint()
+    private var alphaPaint: Paint = Paint()
+    private var datePaint: Paint = Paint()
+    private var todayPaint: Paint = Paint()
+    private var selectedPaint: Paint = Paint()
+    private var clickPaint: Paint = Paint()
     var bgPaint: Paint = Paint()
     var eventPaint: TextPaint = TextPaint()
     var morePaint: Paint = Paint()
 
-    var todayNoticePaint: Paint = Paint()
-    var radius: Float = 34f
+    private var todayNoticePaint: Paint = Paint()
+    private var radius: Float = 34f
 
-    var path = Path()
+    private var path = Path()
     var rect = RectF()
     var corners: FloatArray = floatArrayOf()
     var eventPos: Int = 0
@@ -94,73 +94,70 @@ abstract class CustomCalendarView(context: Context, attrs: AttributeSet) : View(
             _eventCornerRadius = getDimension(R.styleable.CalendarView_eventCornerRadius, 0f)
             _eventLineHeight = getDimension(R.styleable.CalendarView_eventLineHeight, 0f)
 
-            cellPaint = Paint().apply {
-                style = Paint.Style.STROKE
-                color = Color.BLACK
-                strokeWidth = dpToPx(context, 0.5f)
-                isAntiAlias = true
-            }
-
-            alphaPaint = Paint().apply {
-                style = Paint.Style.FILL
-                color = Color.WHITE
-                alpha = 180
-                isAntiAlias = true
-            }
-
-            datePaint = TextPaint().apply {
-                isAntiAlias = true
-                textSize = dayTextSize
-                typeface = Typeface.DEFAULT_BOLD
-                color = context.getColor(R.color.black)
-            }
-
-            todayPaint = TextPaint().apply {
-                isAntiAlias = true
-                textSize = dayTextSize
-                typeface = Typeface.DEFAULT_BOLD
-                color = context.getColor(R.color.white)
-            }
-
-            todayNoticePaint.color = context.getColor(R.color.MainOrange)
-
-            selectedPaint = TextPaint().apply {
-                isAntiAlias = true
-                textSize = dayTextSize
-                typeface = Typeface.DEFAULT_BOLD
-                color = context.getColor(R.color.MainOrange)
-            }
-
-            bgPaint.apply {
-                color = context.getColor(R.color.palette3)
-//                if (!CalendarUtils.isSameMonth(date, firstDayOfMonth)) {
-//                    alpha = 50
-//                }
-            }
-
-            eventPaint = TextPaint().apply {
-                isAntiAlias = true
-                textSize = eventTextSize
-                color = Color.WHITE
-                typeface = Typeface.DEFAULT_BOLD
-//                if (!isSameMonth(date, firstDayOfMonth)) {
-//                    alpha = 50
-//                }
-            }
-
-            morePaint = TextPaint().apply {
-                isAntiAlias = true
-                textSize = eventTextSize
-                color = Color.BLACK
-                typeface = Typeface.DEFAULT_BOLD
-            }
-
+            initPaints(dayTextSize, eventTextSize)
             corners = floatArrayOf(
                 _eventCornerRadius, _eventCornerRadius, //Top left
                 _eventCornerRadius, _eventCornerRadius, //Top right
                 _eventCornerRadius, _eventCornerRadius, //Bottom right
                 _eventCornerRadius, _eventCornerRadius //Bottom left
             )
+        }
+    }
+
+    private fun initPaints(dayTextSize: Float, eventTextSize: Float) {
+        cellPaint = Paint().apply {
+            style = Paint.Style.STROKE
+            color = Color.BLACK
+            strokeWidth = dpToPx(context, 0.5f)
+            isAntiAlias = true
+        }
+
+        alphaPaint = Paint().apply {
+            style = Paint.Style.FILL
+            color = Color.WHITE
+            alpha = 180
+            isAntiAlias = true
+        }
+
+        datePaint = TextPaint().apply {
+            isAntiAlias = true
+            textSize = dayTextSize
+            typeface = Typeface.DEFAULT_BOLD
+            color = context.getColor(R.color.black)
+        }
+
+        todayPaint = TextPaint().apply {
+            isAntiAlias = true
+            textSize = dayTextSize
+            typeface = Typeface.DEFAULT_BOLD
+            color = context.getColor(R.color.white)
+        }
+
+        todayNoticePaint.color = context.getColor(R.color.MainOrange)
+
+        selectedPaint = TextPaint().apply {
+            isAntiAlias = true
+            textSize = dayTextSize
+            typeface = Typeface.DEFAULT_BOLD
+            color = context.getColor(R.color.MainOrange)
+        }
+
+        bgPaint.apply {
+            color = context.getColor(R.color.palette3)
+        }
+
+        eventPaint = TextPaint().apply {
+            isAntiAlias = true
+            textSize = eventTextSize
+            color = Color.WHITE
+            typeface = Typeface.DEFAULT_BOLD
+        }
+
+        morePaint = TextPaint().apply {
+            isAntiAlias = true
+            textSize = eventTextSize
+            color = Color.BLACK
+            typeface = Typeface.DEFAULT_BOLD
         }
     }
 
@@ -185,26 +182,25 @@ abstract class CustomCalendarView(context: Context, attrs: AttributeSet) : View(
                 isScroll = !(abs(endX - startX) < 10 && abs(endY - startY) < 10)
 
                 if (!isScroll) {
-                    val row = (event.y / cellHeight).toInt()
-                    val col = (event.x / cellWidth).toInt()
-                    if (row in 0..5 && col in 0..6) {
-                        val day = days[row * 7 + col]
-                        onDateClickListener?.onDateClick(day, row * 7 + col)
-                        return true
-                    }
+                    handleDateClick(event)
+                    return true
                 }
             }
         }
         return super.onTouchEvent(event)
     }
 
-    fun findMaxOrderInSchedule(startIdx: Int, endIdx: Int): Int {
-        var maxOrder = 0
-        for (i in startIdx..endIdx) {
-            if (orderList[i] > maxOrder) maxOrder = orderList[i]
+    private fun handleDateClick(event: MotionEvent) {
+        val row = (event.y / cellHeight).toInt()
+        val col = (event.x / cellWidth).toInt()
+        if (row in 0..5 && col in 0..6) {
+            val day = days[row * 7 + col]
+            onDateClickListener?.onDateClick(day, row * 7 + col)
         }
+    }
 
-        return maxOrder
+    fun findMaxOrderInSchedule(startIdx: Int, endIdx: Int): Int {
+        return orderList.subList(startIdx, endIdx + 1).maxOrNull() ?: 0
     }
 
     fun setOrder(order: Int, startIdx: Int, endIdx: Int) {
@@ -212,7 +208,6 @@ abstract class CustomCalendarView(context: Context, attrs: AttributeSet) : View(
             orderList[i] = order + 1
         }
     }
-
 
     fun getScheduleBottom(idx: Int): Float {
         return (eventTop + (_eventBetweenPadding * idx) + (_eventHeight * (idx + 1)))
@@ -223,86 +218,41 @@ abstract class CustomCalendarView(context: Context, attrs: AttributeSet) : View(
     }
 
     private fun drawPrevMonthRect(prev: Int, canvas: Canvas?) {
-        if (prev <= 7) {
-            canvas!!.drawRect(
-                RectF(
-                    0f,
-                    0f,
-                    (prev % DAYS_PER_WEEK).toFloat() * cellWidth,
-                    cellHeight
-                ),
-                alphaPaint
-            )
-        } else {
-            canvas!!.drawRect(
-                RectF(
-                    0f,
-                    0f,
-                    (7 * cellWidth),
-                    cellHeight
-                ),
-                alphaPaint
-            )
-            canvas!!.drawRect(
-                RectF(
-                    0f,
-                    cellHeight,
-                    (prev % DAYS_PER_WEEK).toFloat() * cellWidth,
-                    (2 * cellHeight)
-                ),
-                alphaPaint
-            )
-        }
+        val topHeight = if (prev <= 7) cellHeight else 2 * cellHeight
+        canvas!!.drawRect(
+            RectF(
+                0f,
+                0f,
+                (prev % DAYS_PER_WEEK).toFloat() * cellWidth,
+                topHeight
+            ),
+            alphaPaint
+        )
     }
 
     private fun drawNextMonthRect(next: Int, canvas: Canvas?) {
-        if (next <= 7) {
-            canvas!!.drawRect(
-                RectF(
-                    ((42 - next) % DAYS_PER_WEEK).toFloat() * cellWidth,
-                    ((42 - next) / DAYS_PER_WEEK).toFloat() * cellHeight,
-                    (7 * cellWidth),
-                    (6 * cellHeight),
-                ),
-                alphaPaint
-            )
-        } else {
-            canvas!!.drawRect(
-                RectF(
-                    ((42 - next) % DAYS_PER_WEEK).toFloat() * cellWidth,
-                    ((42 - next) / DAYS_PER_WEEK).toFloat() * cellHeight,
-                    (7 * cellWidth),
-                    (5 * cellHeight),
-                ),
-                alphaPaint
-            )
-            canvas!!.drawRect(
-                RectF(
-                    0f,
-                    (5 * cellHeight),
-                    (7 * cellWidth),
-                    (6 * cellHeight),
-                ),
-                alphaPaint
-            )
-        }
+        val bottomHeight = if (next <= 7) 6 * cellHeight else 5 * cellHeight
+        canvas!!.drawRect(
+            RectF(
+                ((42 - next) % DAYS_PER_WEEK).toFloat() * cellWidth,
+                ((42 - next) / DAYS_PER_WEEK).toFloat() * cellHeight,
+                (7 * cellWidth),
+                bottomHeight,
+            ),
+            alphaPaint
+        )
     }
 
-    fun splitWeek(startIdx: Int, endIdx: Int) : ArrayList<StartEnd> {
-        val result  = ArrayList<StartEnd>()
-        result.clear()
+    fun splitWeek(startIdx: Int, endIdx: Int): ArrayList<StartEnd> {
+        val result = ArrayList<StartEnd>()
         var start = if (startIdx == -1) 0 else startIdx
-        var end = if (endIdx == -1) 41 else endIdx
-        var mid = 0
+        val end = if (endIdx == -1) 41 else endIdx
 
         while (start <= end) {
-            mid = (start / 7) * 7 + 6
-            if (mid > end) mid = end
-            result.add(StartEnd(start, mid))
+            val mid = (start / 7) * 7 + 6
+            result.add(StartEnd(start, mid.coerceAtMost(end)))
             start = mid + 1
         }
-
-
         return result
     }
 
@@ -326,23 +276,18 @@ abstract class CustomCalendarView(context: Context, attrs: AttributeSet) : View(
         )
     }
 
-
     fun getScheduleTextStart(startIdx: Int): Float {
         val startX = (startIdx % DAYS_PER_WEEK) * cellWidth + _eventHorizontalPadding
         val additionalMargin = dpToPx(context, 7f)
         return startX + additionalMargin
     }
 
-
     fun getScheduleTextBottom(title: String, startIdx: Int, endIdx: Int, order: Int): Float {
         return (((startIdx / DAYS_PER_WEEK) * cellHeight + eventTop + (_eventBetweenPadding + _eventHeight) * order) + ((endIdx / DAYS_PER_WEEK) * cellHeight + eventTop + (_eventBetweenPadding * order) + (_eventHeight * (order + 1)))) / 2 + eventBounds.height() / 2
     }
 
     private fun isSameMonth(date: DateTime): Boolean {
-        if (date.monthOfYear != DateTime(millis).monthOfYear) {
-            return false
-        }
-        return true
+        return date.monthOfYear == DateTime(millis).monthOfYear
     }
 
     fun setDays(millis: Long) {
@@ -397,7 +342,6 @@ abstract class CustomCalendarView(context: Context, attrs: AttributeSet) : View(
         }
     }
 
-
     private fun drawSelected(canvas: Canvas) {
         val padding = dpToPx(context, 5f)  // 5dp를 픽셀로 변환
 
@@ -443,5 +387,6 @@ abstract class CustomCalendarView(context: Context, attrs: AttributeSet) : View(
         drawPrevMonthRect(prev, canvas)
         drawNextMonthRect(next, canvas)
     }
+
     abstract fun drawSchedules(canvas: Canvas)
 }


### PR DESCRIPTION
## Related Issue
- #235 

## Type of change
<!-- 작업의 종류를 선택해주세요. -->
- [ ] Feature : 새로운 기능 추가
- [x] Bug fix : 버그 수정
- [ ] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [ ] Style : 코드 스타일 및 포맷팅 작업
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## PR Desciption
> 변경 사항 설명
- 캘린더 말줄임표 삭제
- 이모지 사용 시 블럭을 넘어가는 이슈 해결

![image](https://github.com/Namo-log/Android/assets/99808693/e0a5e73d-71d5-44ba-b034-e73984d32a1f)
- 이모지 블럭 수정
![image](https://github.com/Namo-log/Android/assets/99808693/cc367fc2-5a9f-4728-b74e-540cfc04f79b)
- 말줄임표 없이 텍스트 끊기게

