### PR TITLE
[Refactor/262] 카테고리 데이터바인딩 적용

### DIFF
--- a/app/src/main/java/com/mongmong/namo/data/local/entity/home/Category.kt
+++ b/app/src/main/java/com/mongmong/namo/data/local/entity/home/Category.kt
@@ -9,13 +9,13 @@ import java.io.Serializable
 @Entity(tableName="category_table")
 data class Category(
     @PrimaryKey(autoGenerate = true) var categoryId: Long = 0,
-    var name : String = "",
-    var paletteId : Int = 0,
-    var isShare : Boolean = false,
-    var active : Boolean = true,
-    var isUpload : Boolean = false,
-    var state : String = RoomState.DEFAULT.state,
-    var serverId : Long = 0L
+    var name: String = "",
+    var paletteId: Int = 0,
+    var isShare: Boolean = false,
+    var active: Boolean = true,
+    var isUpload: Boolean = false,
+    var state: String = RoomState.DEFAULT.state,
+    var serverId: Long = 0L
 ) : Serializable {
     fun convertLocalCategoryToServer() : CategoryRequestBody {
         return CategoryRequestBody(

--- a/app/src/main/java/com/mongmong/namo/data/repositoriyImpl/CategoryRepositoryImpl.kt
+++ b/app/src/main/java/com/mongmong/namo/data/repositoriyImpl/CategoryRepositoryImpl.kt
@@ -5,6 +5,7 @@ import com.mongmong.namo.data.datasource.category.LocalCategoryDataSource
 import com.mongmong.namo.data.datasource.category.RemoteCategoryDataSource
 import com.mongmong.namo.data.local.entity.home.Category
 import com.mongmong.namo.data.remote.NetworkChecker
+import com.mongmong.namo.data.repositoriyImpl.ScheduleRepositoryImpl.Companion.SUCCESS_CODE
 import com.mongmong.namo.domain.repositories.CategoryRepository
 import com.mongmong.namo.presentation.config.RoomState
 import com.mongmong.namo.presentation.config.UploadState
@@ -30,9 +31,9 @@ class CategoryRepositoryImpl @Inject constructor(
         } ?: Category()
     }
 
-    override suspend fun addCategory(category: Category) {
+    override suspend fun addCategory(category: Category): Boolean {
         Log.d("CategoryRepositoryImpl", "addCategory categoryId: ${category.categoryId}\n$category")
-        remoteCategoryDataSource.addCategoryToServer(category.convertLocalCategoryToServer())
+        return remoteCategoryDataSource.addCategoryToServer(category.convertLocalCategoryToServer()).code == SUCCESS_CODE
         /*
         category.categoryId = localCategoryDataSource.addCategory(category) // 로컬에서 카테고리 생성 후 받아온 categoryId로 업데이트
         if (networkChecker.isOnline()) {
@@ -55,12 +56,12 @@ class CategoryRepositoryImpl @Inject constructor(
          */
     }
 
-    override suspend fun editCategory(category: Category) {
+    override suspend fun editCategory(category: Category): Boolean {
         Log.d("CategoryRepositoryImpl", "editCategory $category")
-        remoteCategoryDataSource.editCategoryToServer(
+        return remoteCategoryDataSource.editCategoryToServer(
             category.serverId,
             category.convertLocalCategoryToServer()
-        )
+        ).code == SUCCESS_CODE
         /*
         localCategoryDataSource.editCategory(category)
         if (networkChecker.isOnline()) {
@@ -78,11 +79,11 @@ class CategoryRepositoryImpl @Inject constructor(
          */
     }
 
-    override suspend fun deleteCategory(category: Category) {
+    override suspend fun deleteCategory(category: Category): Boolean {
         Log.d("CategoryRepositoryImpl", "deleteCategory $category")
-        remoteCategoryDataSource.deleteCategoryToServer(
+        return remoteCategoryDataSource.deleteCategoryToServer(
             category.serverId
-        )
+        ).code == SUCCESS_CODE
         /*
         // room db에서 삭제 상태로 변경
         localCategoryDataSource.deleteCategory(category)

--- a/app/src/main/java/com/mongmong/namo/domain/repositories/CategoryRepository.kt
+++ b/app/src/main/java/com/mongmong/namo/domain/repositories/CategoryRepository.kt
@@ -9,15 +9,15 @@ interface CategoryRepository {
 
     suspend fun addCategory(
         category: Category
-    )
+    ): Boolean
 
     suspend fun editCategory(
         category: Category
-    )
+    ): Boolean
 
     suspend fun deleteCategory(
         category: Category
-    )
+    ): Boolean
 
     suspend fun updateCategoryAfterUpload(
         localId: Long,

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/category/CategoryDetailFragment.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/category/CategoryDetailFragment.kt
@@ -82,7 +82,7 @@ class CategoryDetailFragment(private val isEditMode: Boolean) : Fragment() {
 
             // 저장하기
             categoryDetailSaveTv.setOnClickListener {
-                if (categoryDetailTitleEt.text.toString().isEmpty() || this@CategoryDetailFragment.viewModel.color.value == null) {
+                if (!this@CategoryDetailFragment.viewModel.isValidInput()) {
                     Toast.makeText(requireContext(), "카테고리를 입력해주세요", Toast.LENGTH_SHORT).show()
                     return@setOnClickListener
                 }

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/category/CategoryDetailFragment.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/category/CategoryDetailFragment.kt
@@ -59,7 +59,6 @@ class CategoryDetailFragment(private val isEditMode: Boolean) : Fragment() {
         switchToggle()
         onClickListener()
         clickCategoryItem()
-        setEditTextChangedListener()
 
         initObservers()
 
@@ -248,17 +247,6 @@ class CategoryDetailFragment(private val isEditMode: Boolean) : Fragment() {
             }
             Log.d("debug", "Category Data loaded")
         }
-    }
-
-    private fun setEditTextChangedListener() {
-        binding.categoryDetailTitleEt.addTextChangedListener(object: TextWatcher {
-            override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) { }
-            override fun onTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) { }
-            override fun afterTextChanged(p0: Editable?) {
-                // 카테고리 제목 업데이트
-                viewModel.updateTitle(binding.categoryDetailTitleEt.text.toString())
-            }
-        })
     }
 
     private fun moveToSettingFrag(isEditMode: Boolean) {

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/category/CategoryDetailFragment.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/category/CategoryDetailFragment.kt
@@ -27,6 +27,7 @@ import com.google.gson.reflect.TypeToken
 import com.mongmong.namo.R
 import com.mongmong.namo.presentation.config.PaletteType
 import com.mongmong.namo.presentation.config.CategoryColor
+import com.mongmong.namo.presentation.config.RoomState
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -108,9 +109,16 @@ class CategoryDetailFragment(private val isEditMode: Boolean) : Fragment() {
     }
 
     private fun initObservers() {
-        viewModel.isPostComplete.observe(requireActivity()) { isComplete ->
+        viewModel.isComplete.observe(requireActivity()) { isComplete ->
             // 추가 작업이 완료된 후 뒤로가기
             if (isComplete) {
+                viewModel.completeState.observe(viewLifecycleOwner) { state ->
+                    when(state) {
+                        RoomState.ADDED -> Toast.makeText(requireContext(), "카테고리가 생성되었습니다.", Toast.LENGTH_SHORT).show()
+                        RoomState.EDITED -> Toast.makeText(requireContext(), "카테고리가 수정되었습니다.", Toast.LENGTH_SHORT).show()
+                        else -> {}
+                    }
+                }
                 moveToSettingFrag(isEditMode)
             }
         }
@@ -136,8 +144,6 @@ class CategoryDetailFragment(private val isEditMode: Boolean) : Fragment() {
 
         // 카테고리 편집
         viewModel.editCategory()
-
-        Toast.makeText(requireContext(), "카테고리가 수정되었습니다.", Toast.LENGTH_SHORT).show()
     }
 
     private fun initBasicColor() {

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/category/CategoryDetailFragment.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/category/CategoryDetailFragment.kt
@@ -3,57 +3,39 @@ package com.mongmong.namo.presentation.ui.category
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.text.Editable
+import android.text.TextWatcher
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.Toast
+import androidx.appcompat.widget.SwitchCompat
 import androidx.cardview.widget.CardView
+import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.GridLayoutManager
-import com.mongmong.namo.data.local.NamoDatabase
 import com.mongmong.namo.databinding.FragmentCategoryDetailBinding
 import com.mongmong.namo.presentation.ui.category.CategorySettingFragment.Companion.CATEGORY_DATA
 import com.mongmong.namo.presentation.ui.category.adapter.CategoryPaletteRVAdapter
 import com.mongmong.namo.data.local.entity.home.Category
-import com.mongmong.namo.domain.model.PostCategoryResponse
-import com.mongmong.namo.presentation.utils.NetworkManager
 import com.google.gson.Gson
 import com.google.gson.JsonParseException
 import com.google.gson.reflect.TypeToken
+import com.mongmong.namo.R
 import com.mongmong.namo.presentation.config.PaletteType
 import com.mongmong.namo.presentation.config.CategoryColor
-import com.mongmong.namo.presentation.config.RoomState
-import com.mongmong.namo.presentation.config.UploadState
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class CategoryDetailFragment(private val isEditMode: Boolean) : Fragment() {
-    private var _binding: FragmentCategoryDetailBinding? = null
-    private val binding get() = _binding!!
+    private lateinit var binding: FragmentCategoryDetailBinding
 
     private lateinit var paletteAdapter: CategoryPaletteRVAdapter
 
-    private lateinit var category: Category
-    private var clickable = true // 중복 생성을 방지하기 위함
-
     private val viewModel : CategoryViewModel by viewModels()
-
-    // 카테고리에 들어갈 데이터
-    var categoryId : Long = -1
-    var name: String = ""
-    var color: CategoryColor? = null
-    var share: Boolean = true
-
-    // 서버에 보낼 때 필요한 값
-    var serverId: Long = 0
-    var paletteId: Int = 0
-
-    var selectedPalettePosition: Int? = null // 팔레트 -> 기본 색상 선택 시 사용될 변수
 
     private lateinit var categoryList : List<CardView>
     private lateinit var checkList : List<ImageView>
@@ -63,22 +45,27 @@ class CategoryDetailFragment(private val isEditMode: Boolean) : Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
+        binding = DataBindingUtil.inflate(inflater, R.layout.fragment_category_detail, container, false)
 
-        _binding = FragmentCategoryDetailBinding.inflate(inflater, container, false)
+        binding.apply {
+            viewModel = this@CategoryDetailFragment.viewModel
+            lifecycleOwner = this@CategoryDetailFragment
+        }
 
         initBasicColor()
 
-        checkEditingMode(isEditMode)
+        setInit()
         switchToggle()
         onClickListener()
         clickCategoryItem()
+        setEditTextChangedListener()
 
         initObservers()
 
-        if (color == null) {
+        if (viewModel.color.value == null) {
             initPaletteColorRv(CategoryColor.SCHEDULE)
         } else {
-            initPaletteColorRv(color!!)
+            initPaletteColorRv(viewModel.color.value!!)
         }
 
         return binding.root
@@ -94,41 +81,33 @@ class CategoryDetailFragment(private val isEditMode: Boolean) : Fragment() {
 
             // 저장하기
             categoryDetailSaveTv.setOnClickListener {
-                if (categoryDetailTitleEt.text.toString().isEmpty() || color == null) {
+                if (categoryDetailTitleEt.text.toString().isEmpty() || this@CategoryDetailFragment.viewModel.color.value == null) {
                     Toast.makeText(requireContext(), "카테고리를 입력해주세요", Toast.LENGTH_SHORT).show()
-                } else {
-                    if (clickable) {
-                        // 수정 모드 -> 카테고리 update
-                        if (isEditMode) {
-                            lifecycleScope.launch {
-                                updateData()
-                            }
-                        }
-                        // 생성 모드 -> 카테고리 insert
-                        else {
-                            lifecycleScope.launch {
-                                insertData()
-                            }
-                        }
-                    }
-                    clickable = false
+                    return@setOnClickListener
+                }
+                // 수정 모드 -> 카테고리 update
+                if (isEditMode) {
+                    updateData()
+                }
+                // 생성 모드 -> 카테고리 insert
+                else {
+                    insertData()
                 }
             }
         }
     }
 
-    private fun checkEditingMode(isEditMode: Boolean) {
+    private fun setInit() {
         // 편집 모드
         if (isEditMode) {
             // 이전 화면에서 저장한 spf 받아오기
             loadPref()
+            return
         }
+        viewModel.setCategory(Category(isShare = true))
     }
 
     private fun initObservers() {
-        viewModel.category.observe(requireActivity()) { category ->
-            binding.categoryDetailTitleEt.setText(category.name)
-        }
         viewModel.isPostComplete.observe(requireActivity()) { isComplete ->
             // 추가 작업이 완료된 후 뒤로가기
             if (isComplete) {
@@ -140,23 +119,23 @@ class CategoryDetailFragment(private val isEditMode: Boolean) : Fragment() {
     /** 카테고리 추가 */
     private fun insertData() {
         // RoomDB
-        name = binding.categoryDetailTitleEt.text.toString()
-        category = Category(0, name, color!!.paletteId, share)
-        category.state = RoomState.ADDED.state
+//        name = binding.categoryDetailTitleEt.text.toString()
+//        category = Category(0, name, color!!.paletteId, share)
+//        category.state = RoomState.ADDED.state
 
         // 새 카테고리 등록
-        viewModel.addCategory(category)
+        viewModel.addCategory()
     }
 
     private fun updateData() {
         // RoomDB
-        name = binding.categoryDetailTitleEt.text.toString()
-        category = Category(categoryId, name, color!!.paletteId, share)
-        category.state = RoomState.EDITED.state
-        category.serverId = serverId
+//        name = binding.categoryDetailTitleEt.text.toString()
+//        category = Category(categoryId, name, color!!.paletteId, share)
+//        category.state = RoomState.EDITED.state
+//        category.serverId = serverId
 
         // 카테고리 편집
-        viewModel.editCategory(category)
+        viewModel.editCategory()
 
         Toast.makeText(requireContext(), "카테고리가 수정되었습니다.", Toast.LENGTH_SHORT).show()
     }
@@ -174,24 +153,19 @@ class CategoryDetailFragment(private val isEditMode: Boolean) : Fragment() {
     }
 
     private fun initPaletteColorRv(initCategory: CategoryColor) {
-
         // 기본 팔레트
         val paletteDatas = CategoryColor.findPaletteByPaletteType(PaletteType.BASIC_PALETTE)
 
         for (i: Int in paletteDatas.indices) {
-            if (paletteDatas[i] == color) {
-                selectedPalettePosition = i
-                paletteId = color!!.paletteId
+            if (paletteDatas[i] == viewModel.color.value) {
+                viewModel.updateSelectedPalettePosition(i)
             }
         }
 
-        if (selectedPalettePosition == null) selectedPalettePosition = 0
-
-//        Log.d("CategoryDetailFrag", "selectedPalettePosition: $selectedPalettePosition")
+        if (viewModel.selectedPalettePosition.value == null) viewModel.updateSelectedPalettePosition(0)
 
         // 어댑터 연결
-        paletteAdapter = CategoryPaletteRVAdapter(requireContext(), paletteDatas,
-            initCategory, selectedPalettePosition!!)
+        paletteAdapter = CategoryPaletteRVAdapter(requireContext(), paletteDatas, initCategory, viewModel.selectedPalettePosition.value!!)
         binding.categoryPaletteRv.apply {
             adapter = paletteAdapter
             layoutManager = GridLayoutManager(context, 5)
@@ -204,10 +178,9 @@ class CategoryDetailFragment(private val isEditMode: Boolean) : Fragment() {
                     checkList[j].visibility = View.GONE
                 }
                 // 색상값 세팅
-                this@CategoryDetailFragment.color = selectedColor
-                paletteId = selectedColor.paletteId
+                viewModel.updateCategoryColor(selectedColor)
                 // notifyItemChanged()에서 인자로 넘겨주기 위함. 기본 색상을 클릭했다면 이전에 선택된 팔레트 색상의 체크 표시는 해제
-                selectedPalettePosition = position
+                viewModel.updateSelectedPalettePosition(position)
             }
         })
     }
@@ -221,27 +194,28 @@ class CategoryDetailFragment(private val isEditMode: Boolean) : Fragment() {
                 }
                 // 팔레트 내의 색상도 모두 선택 해제
                 initPaletteColorRv(CategoryColor.SCHEDULE)
-                if (selectedPalettePosition != null) {
-                    paletteAdapter.notifyItemChanged(selectedPalettePosition!!)
+                if (viewModel.selectedPalettePosition.value != null) {
+                    paletteAdapter.notifyItemChanged(viewModel.selectedPalettePosition.value!!)
                 }
                 // 선택한 카테고리 표시
                 checkList[i].visibility = View.VISIBLE
-                color = CategoryColor.findPaletteByPaletteType(PaletteType.DEFAULT_4)[i]
-                paletteId = color!!.paletteId
+                viewModel.updateCategoryColor(CategoryColor.findPaletteByPaletteType(PaletteType.DEFAULT_4)[i])
                 // 이제 팔레트가 아니라 기본 색상에서 설정한 색임
-                selectedPalettePosition = null
+                viewModel.updateSelectedPalettePosition(null)
             }
         }
     }
 
     private fun switchToggle() {
-        val toggle = binding.categoryToggleIv
-        // 첫 진입 시 토글 이미지 세팅
-        toggle.isChecked = share
-        // 토글 클릭 시 이미지 세팅
-        toggle.setOnClickListener {
-            toggle.isChecked = !share
-            share = !share
+        val isShare = viewModel.category.value!!.isShare
+        binding.categoryToggleIv.apply {
+            // 첫 진입 시 토글 이미지 세팅
+            isChecked = isShare
+            // 토글 클릭 시 이미지 세팅
+            setOnClickListener {
+                (it as SwitchCompat).isChecked = !isShare
+                viewModel.updateIsShare(!isShare)
+            }
         }
     }
 
@@ -256,31 +230,29 @@ class CategoryDetailFragment(private val isEditMode: Boolean) : Fragment() {
                 val typeToken = object : TypeToken<Category>() {}.type
                 // 데이터 받기
                 val data: Category = gson.fromJson(json, typeToken)
+                viewModel.setCategory(data)
 
                 // 데이터 값 넣어주기
-                with(binding) {
-                    //카테고리 ID로 넘겨받은 카테고리 세팅
-                    categoryId = data.categoryId
-                    serverId = data.serverId
-                    // 카테고리 이름
-                    categoryDetailTitleEt.setText(data.name)
-                    // 카테고리 색
-                    color = CategoryColor.findCategoryColorByPaletteId(data.paletteId)
-                    if (CategoryColor.findPaletteByPaletteType(PaletteType.DEFAULT_4).contains(color)) {
-                        // 기본 카테고리 체크 표시
-                        checkList[color!!.paletteId - 1].visibility = View.VISIBLE
-                        paletteId = color!!.paletteId
-                    }
-                    // 카테고리 공유 여부
-                    share = data.isShare
+                if (CategoryColor.findPaletteByPaletteType(PaletteType.DEFAULT_4).contains(viewModel.color.value)) {
+                    // 기본 카테고리 체크 표시
+                    checkList[viewModel.category.value!!.paletteId - 1].visibility = View.VISIBLE
                 }
-
-                Log.e("CategoryDetailFrag", "roomId: ${categoryId}, serverId: ${serverId}")
             } catch (e: JsonParseException) { // 파싱이 안 될 경우
                 e.printStackTrace()
             }
             Log.d("debug", "Category Data loaded")
         }
+    }
+
+    private fun setEditTextChangedListener() {
+        binding.categoryDetailTitleEt.addTextChangedListener(object: TextWatcher {
+            override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) { }
+            override fun onTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) { }
+            override fun afterTextChanged(p0: Editable?) {
+                // 카테고리 제목 업데이트
+                viewModel.updateTitle(binding.categoryDetailTitleEt.text.toString())
+            }
+        })
     }
 
     private fun moveToSettingFrag(isEditMode: Boolean) {

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/category/CategoryEditActivity.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/category/CategoryEditActivity.kt
@@ -12,6 +12,7 @@ import com.google.gson.reflect.TypeToken
 import com.mongmong.namo.R
 import com.mongmong.namo.databinding.ActivityCategoryEditBinding
 import com.mongmong.namo.data.local.entity.home.Category
+import com.mongmong.namo.presentation.config.RoomState
 import com.mongmong.namo.presentation.utils.ConfirmDialog
 import com.mongmong.namo.presentation.utils.ConfirmDialogInterface
 import dagger.hilt.android.AndroidEntryPoint
@@ -73,8 +74,17 @@ class CategoryEditActivity : AppCompatActivity(), ConfirmDialogInterface {
     }
 
     private fun initObservers() {
-        viewModel.category.observe(this) {
-            //
+        viewModel.isComplete.observe(this) { isComplete ->
+            // 삭제 작업이 완료된 후 뒤로가기
+            if (isComplete) {
+                viewModel.completeState.observe(this) { state ->
+                    when(state) {
+                        RoomState.DELETED -> Toast.makeText(this, "카테고리가 삭제되었습니다.", Toast.LENGTH_SHORT).show()
+                        else -> {}
+                    }
+                }
+                finish()
+            }
         }
     }
 
@@ -83,8 +93,6 @@ class CategoryEditActivity : AppCompatActivity(), ConfirmDialogInterface {
 //        category.isUpload = UploadState.IS_NOT_UPLOAD.state
 //        category.state = RoomState.DELETED.state
         viewModel.deleteCategory()
-        Toast.makeText(this, "카테고리가 삭제되었습니다.", Toast.LENGTH_SHORT).show()
-        finish()
 
         // 서버 통신
 //            uploadToServer(RoomState.DELETED.state)

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/category/CategoryEditActivity.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/category/CategoryEditActivity.kt
@@ -2,7 +2,6 @@ package com.mongmong.namo.presentation.ui.category
 
 import android.content.Context
 import android.os.Bundle
-import android.util.Log
 import android.widget.Toast
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
@@ -11,14 +10,10 @@ import com.google.gson.Gson
 import com.google.gson.JsonParseException
 import com.google.gson.reflect.TypeToken
 import com.mongmong.namo.R
-import com.mongmong.namo.data.local.NamoDatabase
 import com.mongmong.namo.databinding.ActivityCategoryEditBinding
 import com.mongmong.namo.data.local.entity.home.Category
-import com.mongmong.namo.presentation.config.RoomState
-import com.mongmong.namo.presentation.config.UploadState
 import com.mongmong.namo.presentation.utils.ConfirmDialog
 import com.mongmong.namo.presentation.utils.ConfirmDialogInterface
-import com.mongmong.namo.presentation.utils.NetworkManager
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 
@@ -26,11 +21,6 @@ import kotlinx.coroutines.launch
 class CategoryEditActivity : AppCompatActivity(), ConfirmDialogInterface {
 
     lateinit var binding: ActivityCategoryEditBinding
-
-    private lateinit var category: Category
-
-    var categoryId: Long = -1
-    var serverId: Long = 0
 
     private val viewModel: CategoryViewModel by viewModels()
 
@@ -40,16 +30,15 @@ class CategoryEditActivity : AppCompatActivity(), ConfirmDialogInterface {
         setContentView(binding.root)
 
         loadPref()
-        onClickListener()
+        initClickListeners()
+        initObservers()
 
         supportFragmentManager.beginTransaction()
             .replace(R.id.category_edit_frm, CategoryDetailFragment(true))
             .commitAllowingStateLoss()
-
-        initObservers()
     }
 
-    private fun onClickListener() {
+    private fun initClickListeners() {
 
         // 다크뷰 클릭 시 화면 종료
 //        binding.categoryDarkView.setOnClickListener {
@@ -58,7 +47,6 @@ class CategoryEditActivity : AppCompatActivity(), ConfirmDialogInterface {
 
         // 카테고리 삭제 진행
         binding.categoryDeleteIv.setOnClickListener {
-            Log.d("CategoryEditActivity", "카테고리삭제 클릭")
             // 다이얼로그
             val title = "카테고리를 삭제하시겠어요?"
             val content = "삭제하더라도 카테고리에\n포함된 일정은 사라지지 않습니다."
@@ -78,7 +66,7 @@ class CategoryEditActivity : AppCompatActivity(), ConfirmDialogInterface {
             // 데이터에 타입을 부여하기 위한 typeToken
             val typeToken = object : TypeToken<Category>() {}.type
             // 데이터 받기
-            category = gson.fromJson(json, typeToken)
+            viewModel.setCategory(gson.fromJson(json, typeToken))
         } catch (e: JsonParseException) { // 파싱이 안 될 경우
             e.printStackTrace()
         }
@@ -91,18 +79,15 @@ class CategoryEditActivity : AppCompatActivity(), ConfirmDialogInterface {
     }
 
     private fun deleteCategory() {
-        if (categoryId == 1L || categoryId == 2L) {
-            Toast.makeText(this, "기본 카테고리는 삭제할 수 없습니다", Toast.LENGTH_SHORT).show()
-        } else {
-            category.isUpload = UploadState.IS_NOT_UPLOAD.state
-            category.state = RoomState.DELETED.state
-            viewModel.deleteCategory(category)
-            Toast.makeText(this, "카테고리가 삭제되었습니다.", Toast.LENGTH_SHORT).show()
-            finish()
+        //TODO: 기본 카테고리 삭제 불가 처리
+//        category.isUpload = UploadState.IS_NOT_UPLOAD.state
+//        category.state = RoomState.DELETED.state
+        viewModel.deleteCategory()
+        Toast.makeText(this, "카테고리가 삭제되었습니다.", Toast.LENGTH_SHORT).show()
+        finish()
 
-            // 서버 통신
+        // 서버 통신
 //            uploadToServer(RoomState.DELETED.state)
-        }
     }
 
     override fun onClickYesButton(id: Int) {

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/category/CategoryEditActivity.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/category/CategoryEditActivity.kt
@@ -30,6 +30,11 @@ class CategoryEditActivity : AppCompatActivity(), ConfirmDialogInterface {
         binding = ActivityCategoryEditBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
+        binding.apply {
+            viewModel = this@CategoryEditActivity.viewModel
+            lifecycleOwner = this@CategoryEditActivity
+        }
+
         loadPref()
         initClickListeners()
         initObservers()
@@ -40,14 +45,17 @@ class CategoryEditActivity : AppCompatActivity(), ConfirmDialogInterface {
     }
 
     private fun initClickListeners() {
-
         // 다크뷰 클릭 시 화면 종료
 //        binding.categoryDarkView.setOnClickListener {
 //            finish()
 //        }
 
         // 카테고리 삭제 진행
-        binding.categoryDeleteIv.setOnClickListener {
+        binding.categoryDeleteBtn.setOnClickListener {
+            if (viewModel.canDeleteCategory.value == false) {
+                Toast.makeText(this, "기본 카테고리는 삭제할 수 없습니다.", Toast.LENGTH_SHORT).show()
+                return@setOnClickListener
+            }
             // 다이얼로그
             val title = "카테고리를 삭제하시겠어요?"
             val content = "삭제하더라도 카테고리에\n포함된 일정은 사라지지 않습니다."
@@ -59,6 +67,8 @@ class CategoryEditActivity : AppCompatActivity(), ConfirmDialogInterface {
     }
 
     private fun loadPref() {
+        // 삭제 여부 체크
+        viewModel.setDeliable(intent.getBooleanExtra("canDelete", false))
         // roomDB
         val spf = getSharedPreferences(CategorySettingFragment.CATEGORY_KEY_PREFS, Context.MODE_PRIVATE)
         val gson = Gson()

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/category/CategoryEditActivity.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/category/CategoryEditActivity.kt
@@ -27,13 +27,10 @@ class CategoryEditActivity : AppCompatActivity(), ConfirmDialogInterface {
 
     lateinit var binding: ActivityCategoryEditBinding
 
-    private lateinit var db: NamoDatabase
     private lateinit var category: Category
 
     var categoryId: Long = -1
     var serverId: Long = 0
-
-    private val failList = ArrayList<Category>()
 
     private val viewModel: CategoryViewModel by viewModels()
 
@@ -41,8 +38,6 @@ class CategoryEditActivity : AppCompatActivity(), ConfirmDialogInterface {
         super.onCreate(savedInstanceState)
         binding = ActivityCategoryEditBinding.inflate(layoutInflater)
         setContentView(binding.root)
-
-        db = NamoDatabase.getInstance(this)
 
         loadPref()
         onClickListener()
@@ -87,8 +82,6 @@ class CategoryEditActivity : AppCompatActivity(), ConfirmDialogInterface {
         } catch (e: JsonParseException) { // 파싱이 안 될 경우
             e.printStackTrace()
         }
-//        categoryId = spf.getLong(CategorySettingFragment.CATEGORY_ID, -1)
-//        serverId = spf.getLong(CategorySettingFragment.CATEGORY_SERVER_ID, -1)
     }
 
     private fun initObservers() {
@@ -98,7 +91,6 @@ class CategoryEditActivity : AppCompatActivity(), ConfirmDialogInterface {
     }
 
     private fun deleteCategory() {
-
         if (categoryId == 1L || categoryId == 2L) {
             Toast.makeText(this, "기본 카테고리는 삭제할 수 없습니다", Toast.LENGTH_SHORT).show()
         } else {
@@ -111,30 +103,6 @@ class CategoryEditActivity : AppCompatActivity(), ConfirmDialogInterface {
             // 서버 통신
 //            uploadToServer(RoomState.DELETED.state)
         }
-    }
-
-    private fun uploadToServer(state : String) {
-        // 룸디비에 isUpload, serverId, state 업데이트하기
-        val thread = Thread {
-            category = db.categoryDao.getCategoryWithId(categoryId)
-            viewModel.updateCategoryAfterUpload(categoryId, UploadState.IS_NOT_UPLOAD.state, category.categoryId, RoomState.DEFAULT.state)
-            failList.clear()
-            failList.addAll(db.categoryDao.getNotUploadedCategory() as ArrayList<Category>)
-        }
-        thread.start()
-        try {
-            thread.join()
-        } catch ( e: InterruptedException) {
-            e.printStackTrace()
-        }
-
-        if (!NetworkManager.checkNetworkState(this)) {
-            // 인터넷 연결 안 됨
-            Log.d("CategoryEditActivity", "WIFI ERROR : $failList")
-            return
-        }
-
-//        CategoryDeleteService(this).tryDeleteCategory(serverId, categoryId)
     }
 
     override fun onClickYesButton(id: Int) {

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/category/CategorySettingFragment.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/category/CategorySettingFragment.kt
@@ -27,8 +27,6 @@ class CategorySettingFragment: Fragment() {
 
     private lateinit var categoryRVAdapter: SetCategoryRVAdapter
 
-    private var categoryList: ArrayList<Category> = arrayListOf() // arrayListOf<Category>()
-
     private val viewModel: CategoryViewModel by viewModels()
 
     override fun onCreateView(
@@ -113,10 +111,8 @@ class CategorySettingFragment: Fragment() {
 
     private fun initObserve() {
         viewModel.categoryList.observe(viewLifecycleOwner) {
-            categoryList.clear()
             if (!it.isNullOrEmpty()) {
-                categoryList = it as ArrayList<Category>
-                categoryRVAdapter.addCategory(categoryList)
+                categoryRVAdapter.addCategory(it as ArrayList<Category>)
             }
         }
     }

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/category/CategorySettingFragment.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/category/CategorySettingFragment.kt
@@ -103,9 +103,10 @@ class CategorySettingFragment: Fragment() {
                 // 데이터 저장
                 saveClickedData(category)
                 categoryRVAdapter.notifyItemChanged(position)
-
                 // 편집 화면으로 이동
-                startActivity(Intent(requireActivity(), CategoryEditActivity()::class.java))
+                val intent = Intent(requireActivity(), CategoryEditActivity()::class.java)
+                intent.putExtra("canDelete", (position != 0 && position != 1)) // 기본 카테고리는 삭제 불가
+                startActivity(intent)
             }
         })
     }

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/category/CategorySettingFragment.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/category/CategorySettingFragment.kt
@@ -7,6 +7,7 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
@@ -28,9 +29,7 @@ class CategorySettingFragment: Fragment() {
 
     private var categoryList: ArrayList<Category> = arrayListOf() // arrayListOf<Category>()
 
-    private var gson: Gson = Gson()
-    private val viewModel : CategoryViewModel by viewModels()
-
+    private val viewModel: CategoryViewModel by viewModels()
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -38,7 +37,12 @@ class CategorySettingFragment: Fragment() {
         savedInstanceState: Bundle?
 
     ): View {
-        binding = FragmentCategorySettingBinding.inflate(inflater, container, false)
+        binding = DataBindingUtil.inflate(inflater, R.layout.fragment_category_setting, container, false)
+
+        binding.apply {
+            viewModel = this@CategorySettingFragment.viewModel
+            lifecycleOwner = this@CategorySettingFragment
+        }
 
         initObserve()
         onClickSchedule()
@@ -65,7 +69,7 @@ class CategorySettingFragment: Fragment() {
             activity?.finish()
         }
 
-        //팔레트 설정
+        // 팔레트 설정
         binding.categoryCalendarPaletteSetting.setOnClickListener {
 
         }
@@ -112,7 +116,6 @@ class CategorySettingFragment: Fragment() {
             if (!it.isNullOrEmpty()) {
                 categoryList = it as ArrayList<Category>
                 categoryRVAdapter.addCategory(categoryList)
-                Log.d("getCategories", "initObserve")
             }
         }
     }

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/category/CategoryViewModel.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/category/CategoryViewModel.kt
@@ -37,6 +37,9 @@ class CategoryViewModel @Inject constructor(
     private val _selectedPalettePosition = MutableLiveData<Int?>() // 팔레트 -> 기본 색상 선택 시 사용될 변수
     val selectedPalettePosition: LiveData<Int?> = _selectedPalettePosition
 
+    private val _canDeleteCategory = MutableLiveData<Boolean>(true)
+    val canDeleteCategory: LiveData<Boolean> = _canDeleteCategory
+
     /** 카테고리 조회 */
     fun getCategories() {
         viewModelScope.launch {
@@ -81,6 +84,10 @@ class CategoryViewModel @Inject constructor(
     fun setCategory(category: Category) {
         _category.value = category
         _color.value = CategoryColor.findCategoryColorByPaletteId(category.paletteId)
+    }
+
+    fun setDeliable(canDelete: Boolean) {
+        _canDeleteCategory.value = canDelete
     }
 
     fun updateTitle(title: String) {

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/category/CategoryViewModel.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/category/CategoryViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.viewModelScope
 import com.mongmong.namo.data.local.entity.home.Category
 import com.mongmong.namo.domain.repositories.CategoryRepository
 import com.mongmong.namo.domain.usecase.GetCategoriesUseCase
+import com.mongmong.namo.presentation.config.CategoryColor
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -26,6 +27,12 @@ class CategoryViewModel @Inject constructor(
     private val _isPostComplete = MutableLiveData<Boolean>()
     val isPostComplete: LiveData<Boolean> = _isPostComplete
 
+    private val _color = MutableLiveData<CategoryColor?>()
+    val color: LiveData<CategoryColor?> = _color
+
+    private val _selectedPalettePosition = MutableLiveData<Int?>() // 팔레트 -> 기본 색상 선택 시 사용될 변수
+    val selectedPalettePosition: LiveData<Int?> = _selectedPalettePosition
+
     /** 카테고리 조회 */
     fun getCategories() {
         viewModelScope.launch {
@@ -35,35 +42,59 @@ class CategoryViewModel @Inject constructor(
     }
 
     /** 카테고리 추가 */
-    fun addCategory(category: Category) {
+    fun addCategory() {
         viewModelScope.launch {
-            Log.d("CategoryViewModel", "addCategory $category")
+            Log.d("CategoryViewModel", "addCategory ${_category.value}")
             repository.addCategory(
-                category = category
+                category = _category.value!!
             )
             _isPostComplete.postValue(true)
         }
     }
 
     /** 카테고리 수정 */
-    fun editCategory(category: Category) {
+    fun editCategory() {
         viewModelScope.launch {
-            Log.d("CategoryViewModel", "editCategory $category")
+            Log.d("CategoryViewModel", "editCategory ${_category.value}")
             repository.editCategory(
-                category = category
+                category = _category.value!!
             )
             _isPostComplete.postValue(true)
         }
     }
 
     /** 카테고리 삭제 */
-    fun deleteCategory(category: Category) {
+    fun deleteCategory() {
         viewModelScope.launch {
-            Log.d("CategoryViewModel", "deleteCategory $category")
+            Log.d("CategoryViewModel", "deleteCategory ${_category.value}")
             repository.deleteCategory(
-                category = category
+                category = _category.value!!
             )
         }
+    }
+
+    fun setCategory(category: Category) {
+        _category.value = category
+        _color.value = CategoryColor.findCategoryColorByPaletteId(category.paletteId)
+    }
+
+    fun updateTitle(title: String) {
+        _category.value = _category.value?.copy(
+            name = title
+        )
+    }
+
+    fun updateCategoryColor(color: CategoryColor) {
+        _color.value = color
+        _category.value = _category.value?.copy(paletteId = color.paletteId)
+    }
+
+    fun updateIsShare(isShare: Boolean) {
+        _category.value!!.isShare = isShare
+    }
+
+    fun updateSelectedPalettePosition(pos: Int?) {
+        _selectedPalettePosition.value = pos
     }
 
     fun updateCategoryAfterUpload(localId: Long, isUpload: Boolean, serverId: Long, state: String) {

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/category/CategoryViewModel.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/category/CategoryViewModel.kt
@@ -9,6 +9,7 @@ import com.mongmong.namo.data.local.entity.home.Category
 import com.mongmong.namo.domain.repositories.CategoryRepository
 import com.mongmong.namo.domain.usecase.GetCategoriesUseCase
 import com.mongmong.namo.presentation.config.CategoryColor
+import com.mongmong.namo.presentation.config.RoomState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -24,8 +25,11 @@ class CategoryViewModel @Inject constructor(
     private val _categoryList = MutableLiveData<List<Category>>(emptyList())
     val categoryList: LiveData<List<Category>> = _categoryList
 
-    private val _isPostComplete = MutableLiveData<Boolean>()
-    val isPostComplete: LiveData<Boolean> = _isPostComplete
+    private val _isComplete = MutableLiveData<Boolean>()
+    val isComplete: LiveData<Boolean> = _isComplete
+
+    private val _completeState = MutableLiveData<RoomState>()
+    val completeState: LiveData<RoomState> = _completeState
 
     private val _color = MutableLiveData<CategoryColor?>()
     val color: LiveData<CategoryColor?> = _color
@@ -45,10 +49,10 @@ class CategoryViewModel @Inject constructor(
     fun addCategory() {
         viewModelScope.launch {
             Log.d("CategoryViewModel", "addCategory ${_category.value}")
-            repository.addCategory(
+            _isComplete.postValue(repository.addCategory(
                 category = _category.value!!
-            )
-            _isPostComplete.postValue(true)
+            ))
+            _completeState.value = RoomState.ADDED
         }
     }
 
@@ -56,10 +60,10 @@ class CategoryViewModel @Inject constructor(
     fun editCategory() {
         viewModelScope.launch {
             Log.d("CategoryViewModel", "editCategory ${_category.value}")
-            repository.editCategory(
+            _isComplete.postValue(repository.editCategory(
                 category = _category.value!!
-            )
-            _isPostComplete.postValue(true)
+            ))
+            _completeState.value = RoomState.EDITED
         }
     }
 
@@ -67,9 +71,10 @@ class CategoryViewModel @Inject constructor(
     fun deleteCategory() {
         viewModelScope.launch {
             Log.d("CategoryViewModel", "deleteCategory ${_category.value}")
-            repository.deleteCategory(
+            _isComplete.postValue(repository.deleteCategory(
                 category = _category.value!!
-            )
+            ))
+            _completeState.value = RoomState.DELETED
         }
     }
 

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/category/CategoryViewModel.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/category/CategoryViewModel.kt
@@ -112,7 +112,7 @@ class CategoryViewModel @Inject constructor(
     }
 
     fun isValidInput(): Boolean {
-        return (!category.value?.name.isNullOrEmpty()) && (color.value != null)
+        return (!_category.value?.name.isNullOrEmpty()) && (_color.value != null)
     }
 
     fun updateCategoryAfterUpload(localId: Long, isUpload: Boolean, serverId: Long, state: String) {

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/category/CategoryViewModel.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/category/CategoryViewModel.kt
@@ -31,7 +31,7 @@ class CategoryViewModel @Inject constructor(
     private val _completeState = MutableLiveData<RoomState>()
     val completeState: LiveData<RoomState> = _completeState
 
-    private val _color = MutableLiveData<CategoryColor?>()
+    private val _color = MutableLiveData<CategoryColor?>(null)
     val color: LiveData<CategoryColor?> = _color
 
     private val _selectedPalettePosition = MutableLiveData<Int?>() // 팔레트 -> 기본 색상 선택 시 사용될 변수
@@ -83,7 +83,9 @@ class CategoryViewModel @Inject constructor(
 
     fun setCategory(category: Category) {
         _category.value = category
-        _color.value = CategoryColor.findCategoryColorByPaletteId(category.paletteId)
+        if (category.paletteId != 0) {
+            _color.value = CategoryColor.findCategoryColorByPaletteId(category.paletteId)
+        }
     }
 
     fun setDeliable(canDelete: Boolean) {
@@ -107,6 +109,10 @@ class CategoryViewModel @Inject constructor(
 
     fun updateSelectedPalettePosition(pos: Int?) {
         _selectedPalettePosition.value = pos
+    }
+
+    fun isValidInput(): Boolean {
+        return (!category.value?.name.isNullOrEmpty()) && (color.value != null)
     }
 
     fun updateCategoryAfterUpload(localId: Long, isUpload: Boolean, serverId: Long, state: String) {

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/category/adapter/CategoryPaletteRVAdapter.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/category/adapter/CategoryPaletteRVAdapter.kt
@@ -1,8 +1,6 @@
 package com.mongmong.namo.presentation.ui.category.adapter
 
 import android.content.Context
-import android.graphics.Color
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -33,20 +31,16 @@ class CategoryPaletteRVAdapter(
         val binding: ItemPaletteColorBinding = ItemPaletteColorBinding.inflate(
             LayoutInflater.from(viewGroup.context), viewGroup, false)
 
-//        Log.d("bori", "최초 initColor: $currentSelectPosition")
-
         return ViewHolder(binding)
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         holder.bind(colorList[position])
         holder.apply {
-
             itemView.setOnClickListener {
                 currentSelectPosition = position.toInt()
                 // 팔레트 색상 내에서 단일 선택
                 if (previousSelectPosition != -1) {
-//                    Log.d("shine", "currentPosition: ${currentSelectPosition}, prevPosition: $previousSelectPosition")
                     holder.bind(colorList[position])
                     notifyItemChanged(previousSelectPosition)
                 }
@@ -56,7 +50,6 @@ class CategoryPaletteRVAdapter(
                 mItemClickListener.onItemClick(position, colorList[position])
 
                 previousSelectPosition = currentSelectPosition
-//                Log.d("CategoryPaletteRVA", "selectedPosition: $position")
             }
         }
     }
@@ -64,7 +57,7 @@ class CategoryPaletteRVAdapter(
     override fun getItemCount(): Int = colorList.size
 
     inner class ViewHolder(val binding: ItemPaletteColorBinding): RecyclerView.ViewHolder(binding.root) {
-        val selectIv = binding.itemPaletteSelectIv
+        private val selectIv = binding.itemPaletteSelectIv
 
         fun bind(color : CategoryColor) {
             // 카테고리 색 확인

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/category/adapter/SetCategoryRVAdapter.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/category/adapter/SetCategoryRVAdapter.kt
@@ -1,17 +1,15 @@
 package com.mongmong.namo.presentation.ui.category.adapter
 
 import android.annotation.SuppressLint
-import android.graphics.Color
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.mongmong.namo.databinding.ItemCategoryBinding
 import com.mongmong.namo.data.local.entity.home.Category
-import com.mongmong.namo.presentation.config.CategoryColor
 
 class SetCategoryRVAdapter:  RecyclerView.Adapter<SetCategoryRVAdapter.ViewHolder>(){
 
-    private val categoryList = ArrayList<Category>()
+    private var categoryList = ArrayList<Category>()
     private lateinit var mItemClickListener: MyItemClickListener
 
     fun setCategoryClickListener(itemClickListener: MyItemClickListener) {
@@ -20,8 +18,7 @@ class SetCategoryRVAdapter:  RecyclerView.Adapter<SetCategoryRVAdapter.ViewHolde
 
     @SuppressLint("NotifyDataSetChanged")
     fun addCategory(categories: ArrayList<Category>) {
-        this.categoryList.clear()
-        this.categoryList.addAll(categories)
+        this.categoryList = categories
         notifyDataSetChanged()
     }
 
@@ -50,12 +47,8 @@ class SetCategoryRVAdapter:  RecyclerView.Adapter<SetCategoryRVAdapter.ViewHolde
     inner class ViewHolder(val binding: ItemCategoryBinding): RecyclerView.ViewHolder(binding.root) {
 
         fun bind(category : Category) {
-            binding.itemCategoryColorIv.background.setTint(Color.parseColor(CategoryColor.convertPaletteIdToHexColor(category.paletteId)))
-            binding.itemCategoryNameTv.text = category.name
+            binding.category = category
         }
-
-//        val name : TextView = binding.itemCategoryNameTv
-//        val color = binding.itemCategoryColorIv
     }
 
 }

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/home/adapter/DailyPersonalRVAdapter.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/home/adapter/DailyPersonalRVAdapter.kt
@@ -74,15 +74,17 @@ class DailyPersonalRVAdapter : RecyclerView.Adapter<DailyPersonalRVAdapter.ViewH
 
     inner class ViewHolder(val binding : ItemSchedulePreviewBinding) : RecyclerView.ViewHolder(binding.root) {
         fun bind(schedule : GetMonthScheduleResult) {
+            //TODO: 카테고리를 찾지 못했을 때의 처리
             val category = categoryList.find {
                 if (it.serverId != 0L) it.serverId == schedule.categoryId
-                else it.categoryId == schedule.categoryId }!!
+                else it.categoryId == schedule.categoryId
+            } ?: categoryList.first()
 
             binding.itemCalendarTitle.text = schedule.name
             binding.itemCalendarTitle.isSelected = true
             binding.itemCalendarScheduleTime.text = timeConverter.getScheduleTimeText(schedule.startDate, schedule.endDate)
             binding.itemCalendarScheduleColorView.backgroundTintList = CategoryColor.convertPaletteIdToColorStateList(category.paletteId)
-            binding.itemCalendarScheduleRecord.setColorFilter(ContextCompat.getColor(context,R.color.realGray))
+            binding.itemCalendarScheduleRecord.setColorFilter(ContextCompat.getColor(context, R.color.realGray))
 
             /** 기록 아이콘 색깔 **/
             if (schedule.hasDiary != false)

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/home/schedule/ScheduleDialogCategoryFragment.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/home/schedule/ScheduleDialogCategoryFragment.kt
@@ -33,7 +33,6 @@ class ScheduleDialogCategoryFragment : Fragment() {
     private var schedule: Schedule = Schedule()
 
     private lateinit var categoryRVAdapter: DialogCategoryRVAdapter
-    private var selectedCategory: Long = 0
 
     private val viewModel: CategoryViewModel by viewModels()
 
@@ -50,7 +49,6 @@ class ScheduleDialogCategoryFragment : Fragment() {
         }
 
         schedule = args.schedule
-        selectedCategory = schedule.categoryId
 
         onClickCategoryEdit()
         initObserve()
@@ -72,7 +70,7 @@ class ScheduleDialogCategoryFragment : Fragment() {
 
     private fun setAdapter(categoryList: List<Category>) {
         categoryRVAdapter = DialogCategoryRVAdapter(categoryList)
-        categoryRVAdapter.setSelectedId(selectedCategory)
+        categoryRVAdapter.setSelectedId(schedule.categoryId)
         categoryRVAdapter.setMyItemClickListener(object: DialogCategoryRVAdapter.MyItemClickListener {
             // 아이템 클릭
             override fun onSendId(category: Category) {

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/home/schedule/ScheduleDialogCategoryFragment.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/home/schedule/ScheduleDialogCategoryFragment.kt
@@ -6,12 +6,14 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.LinearLayoutManager
+import com.mongmong.namo.R
 import com.mongmong.namo.presentation.ui.home.schedule.adapter.DialogCategoryRVAdapter
 import com.mongmong.namo.data.local.entity.home.Category
 import com.mongmong.namo.data.local.entity.home.Schedule
@@ -26,27 +28,28 @@ class ScheduleDialogCategoryFragment : Fragment() {
 
     private lateinit var binding : FragmentScheduleDialogCategoryBinding
 
-    private val args : ScheduleDialogCategoryFragmentArgs by navArgs()
+    private val args: ScheduleDialogCategoryFragmentArgs by navArgs()
 
-    private var schedule : Schedule = Schedule()
+    private var schedule: Schedule = Schedule()
 
-    private lateinit var categoryRVAdapter : DialogCategoryRVAdapter
-    private var categoryList : List<Category> = arrayListOf()
-    private var selectedCategory : Long = 0
+    private lateinit var categoryRVAdapter: DialogCategoryRVAdapter
+    private var selectedCategory: Long = 0
 
-    private val viewModel : CategoryViewModel by viewModels()
+    private val viewModel: CategoryViewModel by viewModels()
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
+        binding = DataBindingUtil.inflate(inflater, R.layout.fragment_schedule_dialog_category, container, false)
 
-        binding = FragmentScheduleDialogCategoryBinding.inflate(inflater, container, false)
-        Log.d("DIALOG_CATEGORY", "카테고리 다이얼로그")
+        binding.apply {
+            viewModel = this@ScheduleDialogCategoryFragment.viewModel
+            lifecycleOwner = this@ScheduleDialogCategoryFragment
+        }
 
         schedule = args.schedule
-
         selectedCategory = schedule.categoryId
 
         onClickCategoryEdit()
@@ -67,7 +70,7 @@ class ScheduleDialogCategoryFragment : Fragment() {
         }
     }
 
-    private fun setAdapter() {
+    private fun setAdapter(categoryList: List<Category>) {
         categoryRVAdapter = DialogCategoryRVAdapter(categoryList)
         categoryRVAdapter.setSelectedId(selectedCategory)
         categoryRVAdapter.setMyItemClickListener(object: DialogCategoryRVAdapter.MyItemClickListener {
@@ -92,8 +95,7 @@ class ScheduleDialogCategoryFragment : Fragment() {
     private fun initObserve() {
         viewModel.categoryList.observe(viewLifecycleOwner) {
             if (!it.isNullOrEmpty()) {
-                categoryList = it
-                setAdapter()
+                setAdapter(it)
             }
         }
     }

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/home/schedule/adapter/DialogCategoryRVAdapter.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/home/schedule/adapter/DialogCategoryRVAdapter.kt
@@ -6,7 +6,6 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.mongmong.namo.data.local.entity.home.Category
 import com.mongmong.namo.databinding.ItemDialogScheduleCategoryBinding
-import com.mongmong.namo.presentation.config.CategoryColor
 
 class DialogCategoryRVAdapter(
     private val categoryList: List<Category>
@@ -28,11 +27,9 @@ class DialogCategoryRVAdapter(
         this.selectedId = id
     }
 
-    inner class ViewHolder(val binding : ItemDialogScheduleCategoryBinding) : RecyclerView.ViewHolder(binding.root) {
+    inner class ViewHolder(val binding: ItemDialogScheduleCategoryBinding) : RecyclerView.ViewHolder(binding.root) {
         fun bind(category : Category) {
-            binding.categoryColorView.backgroundTintList = CategoryColor.convertPaletteIdToColorStateList(category.paletteId)
-            binding.categoryNameTv.text = category.name
-
+            binding.category = category
             if (category.categoryId == selectedId) {
                 binding.categorySelectedIv.visibility = View.VISIBLE
             } else {
@@ -58,5 +55,4 @@ class DialogCategoryRVAdapter(
     }
 
     override fun getItemCount(): Int = categoryList.size
-
 }

--- a/app/src/main/res/layout/activity_category_edit.xml
+++ b/app/src/main/res/layout/activity_category_edit.xml
@@ -1,36 +1,52 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
+<layout  xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <!-- 카테고리 편집시 -->
+    <data>
+        <variable
+            name="viewModel"
+            type="com.mongmong.namo.presentation.ui.category.CategoryViewModel" />
+    </data>
 
-    <ImageView
-        android:id="@+id/category_delete_iv"
-        android:layout_width="60dp"
-        android:layout_height="60dp"
-        android:src="@drawable/ic_category_delete"
-        android:scaleType="fitXY"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        android:layout_marginBottom="10dp"
-        app:layout_constraintBottom_toBottomOf="@id/category_dark_view"/>
-
-    <View
-        android:id="@+id/category_dark_view"
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:background="@color/transparent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toTopOf="@id/category_edit_frm"/>
+        android:layout_height="match_parent">
 
-    <FrameLayout
-        android:id="@+id/category_edit_frm"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_marginTop="100dp"/>
+        <!-- 카테고리 편집시 -->
+        <androidx.cardview.widget.CardView
+            android:id="@+id/category_delete_btn"
+            android:layout_width="65dp"
+            android:layout_height="70dp"
+            android:layout_marginBottom="10dp"
+            app:cardBackgroundColor="@color/white"
+            app:cardCornerRadius="25dp"
+            app:cardElevation="5dp"
+            app:cardUseCompatPadding="true"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintBottom_toBottomOf="@id/category_dark_view">
+            <androidx.appcompat.widget.AppCompatImageView
+                android:layout_width="30dp"
+                android:layout_height="30dp"
+                android:background="@drawable/ic_delete_schedule"
+                android:backgroundTint="@{viewModel.canDeleteCategory ? @color/black : @color/disableTextGray}"
+                android:layout_gravity="center"/>
+        </androidx.cardview.widget.CardView>
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+        <View
+            android:id="@+id/category_dark_view"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:background="@color/transparent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toTopOf="@id/category_edit_frm"/>
+
+        <FrameLayout
+            android:id="@+id/category_edit_frm"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_marginTop="100dp"/>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/fragment_category_detail.xml
+++ b/app/src/main/res/layout/fragment_category_detail.xml
@@ -3,6 +3,13 @@
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
+    <data>
+        <import type="com.mongmong.namo.presentation.config.CategoryColor"/>
+        <variable
+            name="viewModel"
+            type="com.mongmong.namo.presentation.ui.category.CategoryViewModel" />
+    </data>
+
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
@@ -73,9 +80,11 @@
                     android:id="@+id/category_detail_title_et"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:hint="@string/category_new"
+                    android:hint="@string/category_hint"
+                    android:textColorHint="@color/editTextGray"
                     android:paddingVertical="5dp"
                     android:singleLine="true"
+                    android:text="@{viewModel.category.name}"
                     android:textColor="@color/textGray"
                     android:textSize="22sp"
                     android:background="@null"

--- a/app/src/main/res/layout/fragment_category_detail.xml
+++ b/app/src/main/res/layout/fragment_category_detail.xml
@@ -84,7 +84,7 @@
                     android:textColorHint="@color/editTextGray"
                     android:paddingVertical="5dp"
                     android:singleLine="true"
-                    android:text="@{viewModel.category.name}"
+                    android:text="@={viewModel.category.name}"
                     android:textColor="@color/textGray"
                     android:textSize="22sp"
                     android:background="@null"

--- a/app/src/main/res/layout/fragment_category_setting.xml
+++ b/app/src/main/res/layout/fragment_category_setting.xml
@@ -3,6 +3,12 @@
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
+    <data>
+        <variable
+            name="viewModel"
+            type="com.mongmong.namo.presentation.ui.category.CategoryViewModel" />
+    </data>
+
     <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
         android:layout_width="match_parent"
         android:layout_height="match_parent">

--- a/app/src/main/res/layout/fragment_schedule_dialog_category.xml
+++ b/app/src/main/res/layout/fragment_schedule_dialog_category.xml
@@ -1,80 +1,86 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:orientation="vertical">
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+        <variable
+            name="viewModel"
+            type="com.mongmong.namo.presentation.ui.category.CategoryViewModel" />
+    </data>
 
     <LinearLayout
-        android:id="@+id/dialog_schedule_category_header_layout"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal">
-
-        <TextView
-            android:id="@+id/dialog_schedule_category_header_tv"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_weight="6"
-            android:text="@string/category"
-            android:textStyle="bold"
-            android:textColor="@color/black"
-            android:textSize="15sp"
-            android:textAlignment="center"/>
-
-    </LinearLayout>
-
-    <androidx.core.widget.NestedScrollView
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:overScrollMode="never">
+        android:layout_height="match_parent"
+        android:orientation="vertical">
 
         <LinearLayout
+            android:id="@+id/dialog_schedule_category_header_layout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical">
+            android:orientation="horizontal">
 
-            <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/dialog_schedule_category_rv"
+            <TextView
+                android:id="@+id/dialog_schedule_category_header_tv"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="25dp"
-                android:overScrollMode="never"
-                tools:listitem="@layout/item_dialog_schedule_category"/>
-
-            <androidx.constraintlayout.widget.ConstraintLayout
-                android:id="@+id/dialog_schedule_category_edit_cv"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:paddingVertical="5dp"
-                android:layout_marginBottom="50dp">
-
-                <androidx.appcompat.widget.AppCompatImageView
-                    android:id="@+id/dialog_schedule_category_edit_iv"
-                    android:layout_width="18dp"
-                    android:layout_height="18dp"
-                    android:src="@drawable/ic_category_edit"
-                    app:layout_constraintTop_toTopOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"/>
-
-                <TextView
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="20dp"
-                    android:text="@string/category_edit"
-                    android:textSize="15sp"
-                    android:textColor="@color/textGray"
-                    app:layout_constraintStart_toEndOf="@id/dialog_schedule_category_edit_iv"
-                    app:layout_constraintTop_toTopOf="@id/dialog_schedule_category_edit_iv"
-                    app:layout_constraintBottom_toBottomOf="@id/dialog_schedule_category_edit_iv"
-                    app:layout_constraintEnd_toEndOf="parent" />
-
-            </androidx.constraintlayout.widget.ConstraintLayout>
+                android:layout_weight="6"
+                android:text="@string/category"
+                android:textStyle="bold"
+                android:textColor="@color/black"
+                android:textSize="15sp"
+                android:textAlignment="center"/>
 
         </LinearLayout>
-    </androidx.core.widget.NestedScrollView>
 
+        <androidx.core.widget.NestedScrollView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:overScrollMode="never">
 
-    
-</LinearLayout>
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+                <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/dialog_schedule_category_rv"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="25dp"
+                    android:overScrollMode="never"
+                    tools:listitem="@layout/item_dialog_schedule_category"/>
+
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:id="@+id/dialog_schedule_category_edit_cv"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:paddingVertical="5dp"
+                    android:layout_marginBottom="50dp">
+
+                    <androidx.appcompat.widget.AppCompatImageView
+                        android:id="@+id/dialog_schedule_category_edit_iv"
+                        android:layout_width="18dp"
+                        android:layout_height="18dp"
+                        android:src="@drawable/ic_category_edit"
+                        app:layout_constraintTop_toTopOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"/>
+
+                    <TextView
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="20dp"
+                        android:text="@string/category_edit"
+                        android:textSize="15sp"
+                        android:textColor="@color/textGray"
+                        app:layout_constraintStart_toEndOf="@id/dialog_schedule_category_edit_iv"
+                        app:layout_constraintTop_toTopOf="@id/dialog_schedule_category_edit_iv"
+                        app:layout_constraintBottom_toBottomOf="@id/dialog_schedule_category_edit_iv"
+                        app:layout_constraintEnd_toEndOf="parent" />
+
+                </androidx.constraintlayout.widget.ConstraintLayout>
+
+            </LinearLayout>
+        </androidx.core.widget.NestedScrollView>
+    </LinearLayout>
+</layout>

--- a/app/src/main/res/layout/item_category.xml
+++ b/app/src/main/res/layout/item_category.xml
@@ -1,80 +1,84 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:layout_marginStart="12dp"
-    android:layout_marginTop="15dp"
-    android:layout_marginEnd="12dp">
+    xmlns:tools="http://schemas.android.com/tools">
+    <data>
+        <import type="com.mongmong.namo.presentation.config.CategoryColor"/>
+        <variable
+            name="category"
+            type="com.mongmong.namo.data.local.entity.home.Category" />
+    </data>
 
-    <LinearLayout
-        android:id="@+id/item_category_background"
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@drawable/category_box"
-        android:orientation="horizontal"
-        android:padding="15dp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
-
+        android:layout_marginStart="12dp"
+        android:layout_marginTop="15dp"
+        android:layout_marginEnd="12dp">
 
         <LinearLayout
-            android:layout_width="wrap_content"
+            android:id="@+id/item_category_background"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:layout_marginVertical="3dp"
-            android:orientation="horizontal">
+            android:background="@drawable/category_box"
+            android:orientation="horizontal"
+            android:padding="15dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
 
-            <androidx.cardview.widget.CardView
-                android:id="@+id/item_category_color_iv"
-                android:layout_width="20dp"
-                android:layout_height="20dp"
-                app:cardBackgroundColor="@color/schedule"
-                app:cardCornerRadius="25dp"
-                app:cardElevation="0dp">
-            </androidx.cardview.widget.CardView>
 
-            <!--            <de.hdodenhof.circleimageview.CircleImageView-->
-            <!--                android:id="@+id/item_category_color_iv"-->
-            <!--                android:layout_width="20dp"-->
-            <!--                android:layout_height="20dp"-->
-            <!--                android:src="@color/schedule" />-->
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:layout_marginVertical="3dp"
+                android:orientation="horizontal">
 
-            <androidx.constraintlayout.widget.ConstraintLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content">
-
-                <TextView
-                    android:id="@+id/item_category_name_tv"
-                    android:layout_width="80dp"
-                    android:layout_height="match_parent"
-                    android:layout_marginEnd="10dp"
-                    android:textAlignment="textEnd"
-                    android:ellipsize="end"
-                    android:singleLine="true"
-                    android:textColor="@color/textGray"
-                    android:textSize="15sp"
-                    android:textStyle="bold"
-                    android:text="일정"
-                    app:layout_constraintEnd_toStartOf="@id/item_category_edit_iv"
-                    app:layout_constraintTop_toTopOf="@id/item_category_edit_iv"
-                    app:layout_constraintBottom_toBottomOf="@id/item_category_edit_iv"/>
-
-                <ImageView
-                    android:id="@+id/item_category_edit_iv"
-                    android:layout_width="10dp"
+                <androidx.cardview.widget.CardView
+                    android:id="@+id/item_category_color_iv"
+                    android:layout_width="20dp"
                     android:layout_height="20dp"
-                    android:padding="1dp"
-                    android:layout_gravity="center_vertical"
-                    android:src="@drawable/ic_arrow_right_gray"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintTop_toTopOf="parent"
-                    app:layout_constraintBottom_toBottomOf="parent"/>
+                    app:cardBackgroundColor="@{CategoryColor.convertPaletteIdToColorStateList(category.paletteId)}"
+                    app:cardCornerRadius="25dp"
+                    app:cardElevation="0dp"
+                    tools:backgroundTint="@color/schedule">
+                </androidx.cardview.widget.CardView>
 
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content">
 
-            </androidx.constraintlayout.widget.ConstraintLayout>
+                    <TextView
+                        android:id="@+id/item_category_name_tv"
+                        android:layout_width="80dp"
+                        android:layout_height="match_parent"
+                        android:layout_marginEnd="10dp"
+                        android:textAlignment="textEnd"
+                        android:ellipsize="end"
+                        android:singleLine="true"
+                        android:textColor="@color/textGray"
+                        android:textSize="15sp"
+                        android:textStyle="bold"
+                        android:text="@{category.name}"
+                        app:layout_constraintEnd_toStartOf="@id/item_category_edit_iv"
+                        app:layout_constraintTop_toTopOf="@id/item_category_edit_iv"
+                        app:layout_constraintBottom_toBottomOf="@id/item_category_edit_iv"
+                        tools:text="일정"/>
 
+                    <ImageView
+                        android:id="@+id/item_category_edit_iv"
+                        android:layout_width="10dp"
+                        android:layout_height="20dp"
+                        android:padding="1dp"
+                        android:layout_gravity="center_vertical"
+                        android:src="@drawable/ic_arrow_right_gray"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintTop_toTopOf="parent"
+                        app:layout_constraintBottom_toBottomOf="parent"/>
+
+                </androidx.constraintlayout.widget.ConstraintLayout>
+            </LinearLayout>
         </LinearLayout>
-    </LinearLayout>
-</androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/item_dialog_schedule_category.xml
+++ b/app/src/main/res/layout/item_dialog_schedule_category.xml
@@ -1,43 +1,56 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_marginBottom="5dp"
-    android:paddingVertical="5dp">
-    
-    <View
-        android:id="@+id/category_color_view"
-        android:layout_width="20dp"
-        android:layout_height="20dp"
-        android:background="@drawable/border_round_all_circle"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintStart_toStartOf="parent"/>
+    xmlns:tools="http://schemas.android.com/tools">
 
-    <androidx.appcompat.widget.AppCompatImageView
-        android:id="@+id/category_selected_iv"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:src="@drawable/ic_selected_check"
-        app:layout_constraintTop_toTopOf="@id/category_color_view"
-        app:layout_constraintBottom_toBottomOf="@id/category_color_view"
-        app:layout_constraintStart_toStartOf="@id/category_color_view"
-        app:layout_constraintEnd_toEndOf="@id/category_color_view"
-        android:padding="5dp"
-        android:visibility="gone"/>
+    <data>
+        <import type="com.mongmong.namo.presentation.config.CategoryColor"/>
+        <variable
+            name="category"
+            type="com.mongmong.namo.data.local.entity.home.Category" />
+    </data>
 
-    <TextView
-        android:id="@+id/category_name_tv"
-        android:layout_width="0dp"
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginStart="20dp"
-        android:textSize="15sp"
-        android:textColor="@color/textGray"
-        app:layout_constraintTop_toTopOf="@id/category_color_view"
-        app:layout_constraintBottom_toBottomOf="@id/category_color_view"
-        app:layout_constraintStart_toEndOf="@id/category_color_view"
-        app:layout_constraintEnd_toEndOf="parent"
-        tools:text="일정(기본)"/>
+        android:layout_marginBottom="5dp"
+        android:paddingVertical="5dp">
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+        <View
+            android:id="@+id/category_color_view"
+            android:layout_width="20dp"
+            android:layout_height="20dp"
+            android:backgroundTint="@{CategoryColor.convertPaletteIdToColorStateList(category.paletteId)}"
+            android:background="@drawable/border_round_all_circle"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            tools:backgroundTint="@color/schedule"/>
+
+        <androidx.appcompat.widget.AppCompatImageView
+            android:id="@+id/category_selected_iv"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:src="@drawable/ic_selected_check"
+            app:layout_constraintTop_toTopOf="@id/category_color_view"
+            app:layout_constraintBottom_toBottomOf="@id/category_color_view"
+            app:layout_constraintStart_toStartOf="@id/category_color_view"
+            app:layout_constraintEnd_toEndOf="@id/category_color_view"
+            android:padding="5dp"
+            android:visibility="gone"/>
+
+        <TextView
+            android:id="@+id/category_name_tv"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="20dp"
+            android:text="@{category.name}"
+            android:textSize="15sp"
+            android:textColor="@color/textGray"
+            app:layout_constraintTop_toTopOf="@id/category_color_view"
+            app:layout_constraintBottom_toBottomOf="@id/category_color_view"
+            app:layout_constraintStart_toEndOf="@id/category_color_view"
+            app:layout_constraintEnd_toEndOf="parent"
+            tools:text="일정(기본)"/>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -120,6 +120,7 @@
     <string name="category_palette">팔레트</string>
     <string name="palette_normal">기본 팔레트</string>
     <string name="category_new">새 카테고리</string>
+    <string name="category_hint">카테고리 이름</string>
     <string name="category_detail_normal_color">기본 색상</string>
     <string name="category_detail_isShare">공유 설정</string>
     <string name="category_detail_setting">카테고리 설정</string>


### PR DESCRIPTION
## Related Issue
- #262 

## Type of change
<!-- 작업의 종류를 선택해주세요. -->
- [ ] Feature : 새로운 기능 추가
- [ ] Bug fix : 버그 수정
- [x] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [ ] Style : 코드 스타일 및 포맷팅 작업
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## PR Description
> 변경 사항 설명
- 카테고리 상세, 리스트에 데이터바인딩을 적용했습니다
- 카테고리 생성, 수정, 삭제 요청이 성공함에 따라 후속 처리를 하도록 했습니다.
- 기본 카테고리는 카테고리 삭제가 불가능하도록 막았습니다.

## Requirements for Reviewer
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

- 뷰모델에서 API 응답 성공 여부인`isComplete`와 요쳥 유형에 따른 `completeState`으로 요청 결과에 따른 처리를 할 수 있도록 했는데 이 방식이 괜찮을지 봐주시면 감사하겠습니다. (지금은 뷰모델마다 다른 방식으로 쓰여 있는데 서버 응답값으로 오류 처리를 들어가게 된다면 통일하는 게 좋을 거 같습니다!)

## PR Log

> PR 작업하면서 고민했던 내용, 해결한 내용, 고민 중인 내용 등

### 새롭게 배운 것

- 리사이클러뷰에 데이터바인딩을 적용하는 것은 처음이었습니다.

### 고민 중인 사항

- 현재 삭제 버튼이 없는 CategoryActivity와 삭제 버튼이 있는 CategoryEditActivity가 구분되어 있는데, 조금 불필요하다는 생각이 들었습니다. ScheduleActivity와 비슷하게 하나의 액티비티에서 navGraph로 화면을 이동할 수 있도록 후에 이슈를 만들어 작업하겠습니다! 데이터를 args로 넘기면 코드가 훨씬 간결해질 수 있을 것 같습니다.

## 첨부 자료

-
