### PR TITLE
[Refactor/278] remoteConfig로 baseUrl 사용, 모듈 수정

### DIFF
--- a/app/src/main/java/com/mongmong/namo/data/datasource/auth/RemoteAuthDataSource.kt
+++ b/app/src/main/java/com/mongmong/namo/data/datasource/auth/RemoteAuthDataSource.kt
@@ -1,7 +1,9 @@
 package com.mongmong.namo.data.datasource.auth
 
 import android.util.Log
+import com.mongmong.namo.data.remote.AnonymousApiService
 import com.mongmong.namo.data.remote.AuthApiService
+import com.mongmong.namo.data.remote.ReissuanceApiService
 import com.mongmong.namo.domain.model.LoginBody
 import com.mongmong.namo.domain.model.LoginResponse
 import com.mongmong.namo.domain.model.LoginResult
@@ -14,7 +16,9 @@ import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 class RemoteAuthDataSource @Inject constructor(
-    private val authApiService: AuthApiService
+    private val authApiService: AuthApiService,
+    private val anonymousApiService: AnonymousApiService,
+    private val reissuanceApiService: ReissuanceApiService
 ) {
     suspend fun postKakaoLogin(
         tokenBody: LoginBody
@@ -28,7 +32,7 @@ class RemoteAuthDataSource @Inject constructor(
         )
         withContext(Dispatchers.IO) {
             runCatching {
-                authApiService.postKakaoSDK(tokenBody)
+                anonymousApiService.postKakaoSDK(tokenBody)
             }.onSuccess {
                 Log.d("RemoteAuthDataSource", "postKakaoLogin Success $it")
                 loginResponse = it
@@ -51,7 +55,7 @@ class RemoteAuthDataSource @Inject constructor(
         )
         withContext(Dispatchers.IO) {
             runCatching {
-                authApiService.postNaverSDK(tokenBody)
+                anonymousApiService.postNaverSDK(tokenBody)
             }.onSuccess {
                 Log.d("RemoteAuthDataSource", "postNaverLogin Success $it")
                 loginResponse = it
@@ -73,7 +77,7 @@ class RemoteAuthDataSource @Inject constructor(
         )
         withContext(Dispatchers.IO) {
             runCatching {
-                authApiService.refreshToken(tokenBody)
+                reissuanceApiService.refreshToken(tokenBody)
             }.onSuccess {
                 Log.d("RemoteAuthDataSource", "postTokenRefresh Success $it")
                 refreshResponse = it
@@ -101,13 +105,11 @@ class RemoteAuthDataSource @Inject constructor(
         return isSuccess
     }
 
-    suspend fun postKakaoQuit(
-        bearerToken: String
-    ): Boolean {
+    suspend fun postKakaoQuit(): Boolean {
         var isSuccess = false
         withContext(Dispatchers.IO) {
             runCatching {
-                authApiService.postKakaoQuit(bearerToken)
+                authApiService.postKakaoQuit()
             }.onSuccess {
                 Log.d("RemoteAuthDataSource", "postKakaoQuit Success $it")
                 isSuccess = true
@@ -119,12 +121,11 @@ class RemoteAuthDataSource @Inject constructor(
     }
 
     suspend fun postNaverQuit(
-        bearerToken: String
     ): Boolean {
         var isSuccess = false
         withContext(Dispatchers.IO) {
             runCatching {
-                authApiService.postNaverQuit(bearerToken)
+                authApiService.postNaverQuit()
             }.onSuccess {
                 Log.d("RemoteAuthDataSource", "postNaverQuit Success $it")
                 isSuccess = true

--- a/app/src/main/java/com/mongmong/namo/data/remote/AnonymousApiService.kt
+++ b/app/src/main/java/com/mongmong/namo/data/remote/AnonymousApiService.kt
@@ -1,0 +1,23 @@
+package com.mongmong.namo.data.remote
+
+import com.mongmong.namo.domain.model.LoginBody
+import com.mongmong.namo.domain.model.LoginResponse
+import com.mongmong.namo.domain.model.RefreshResponse
+import com.mongmong.namo.domain.model.TokenBody
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+interface AnonymousApiService {
+    // SDK 카카오 로그인
+    @POST("auths/kakao/signup")
+    suspend fun postKakaoSDK(
+        @Body body: LoginBody
+    ): LoginResponse
+
+    // SDK 네이버 로그인
+    @POST("auths/naver/signup")
+    suspend fun postNaverSDK(
+        @Body body: LoginBody
+    ): LoginResponse
+
+}

--- a/app/src/main/java/com/mongmong/namo/data/remote/AuthApiService.kt
+++ b/app/src/main/java/com/mongmong/namo/data/remote/AuthApiService.kt
@@ -1,36 +1,13 @@
 package com.mongmong.namo.data.remote
 
-import com.mongmong.namo.domain.model.LoginBody
 import com.mongmong.namo.domain.model.AuthResponse
-import com.mongmong.namo.domain.model.LoginResponse
 import com.mongmong.namo.domain.model.LogoutBody
-import com.mongmong.namo.domain.model.RefreshResponse
-import com.mongmong.namo.domain.model.TokenBody
 import com.mongmong.namo.presentation.config.BaseResponse
 import retrofit2.http.Body
 import retrofit2.http.Header
 import retrofit2.http.POST
 
 interface AuthApiService {
-    /** 로그인 */
-    // SDK 카카오 로그인
-    @POST("auths/kakao/signup")
-    suspend fun postKakaoSDK(
-        @Body body: LoginBody
-    ): LoginResponse
-
-    // SDK 네이버 로그인
-    @POST("auths/naver/signup")
-    suspend fun postNaverSDK(
-        @Body body: LoginBody
-    ): LoginResponse
-
-    // 토큰 재발급
-    @POST("auths/reissuance")
-    suspend fun refreshToken(
-        @Body body: TokenBody
-    ): RefreshResponse
-
     // 로그아웃
     @POST("auths/logout")
     suspend fun postLogout(
@@ -40,13 +17,9 @@ interface AuthApiService {
     /** 회원탈퇴 */
     // 카카오 회원탈퇴
     @POST("auths/kakao/delete")
-    suspend fun postKakaoQuit(
-        @Header("authorization") accessToken: String
-    ): AuthResponse
+    suspend fun postKakaoQuit(): AuthResponse
 
     // 네이버 회원탈퇴
     @POST("auths/naver/delete")
-    suspend fun postNaverQuit(
-        @Header("authorization") accessToken: String
-    ): BaseResponse
+    suspend fun postNaverQuit(): BaseResponse
 }

--- a/app/src/main/java/com/mongmong/namo/data/remote/ReissuanceApiService.kt
+++ b/app/src/main/java/com/mongmong/namo/data/remote/ReissuanceApiService.kt
@@ -1,0 +1,15 @@
+package com.mongmong.namo.data.remote
+
+import com.mongmong.namo.domain.model.RefreshResponse
+import com.mongmong.namo.domain.model.TokenBody
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+/** 추후 헤더 없이 AnonymousApiService로 이전 예정 */
+interface ReissuanceApiService {
+    // 토큰 재발급
+    @POST("auths/reissuance")
+    suspend fun refreshToken(
+        @Body body: TokenBody
+    ): RefreshResponse
+}

--- a/app/src/main/java/com/mongmong/namo/data/repositoriyImpl/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/mongmong/namo/data/repositoriyImpl/AuthRepositoryImpl.kt
@@ -31,11 +31,11 @@ class AuthRepositoryImpl @Inject constructor(
         return remoteAuthDataSource.postLogout(LogoutBody(accessToken))
     }
 
-    override suspend fun postKakaoQuit(bearerToken: String): Boolean {
-        return remoteAuthDataSource.postKakaoQuit(bearerToken)
+    override suspend fun postKakaoQuit(): Boolean {
+        return remoteAuthDataSource.postKakaoQuit()
     }
 
-    override suspend fun postNaverQuit(bearerToken: String): Boolean {
-        return remoteAuthDataSource.postNaverQuit(bearerToken)
+    override suspend fun postNaverQuit(): Boolean {
+        return remoteAuthDataSource.postNaverQuit()
     }
 }

--- a/app/src/main/java/com/mongmong/namo/domain/repositories/AuthRepository.kt
+++ b/app/src/main/java/com/mongmong/namo/domain/repositories/AuthRepository.kt
@@ -28,11 +28,7 @@ interface AuthRepository {
 
     /** 회원탈퇴 */
     // 카카오
-    suspend fun postKakaoQuit(
-        bearerToken: String
-    ): Boolean
+    suspend fun postKakaoQuit(): Boolean
     // 네이버
-    suspend fun postNaverQuit(
-        bearerToken: String
-    ): Boolean
+    suspend fun postNaverQuit(): Boolean
 }

--- a/app/src/main/java/com/mongmong/namo/presentation/config/ApplicationClass.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/config/ApplicationClass.kt
@@ -20,8 +20,8 @@ class ApplicationClass: Application() {
     lateinit var basicRetrofit: Retrofit
 
     @Inject
-    @NetworkModule.ReissuanceRetrofit
-    lateinit var reissuanceRetrofit: Retrofit
+    @NetworkModule.AnonymousRetrofit
+    lateinit var anonymousRetrofit: Retrofit
 
     init {
         instance = this

--- a/app/src/main/java/com/mongmong/namo/presentation/config/RemoteConfigWrapper.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/config/RemoteConfigWrapper.kt
@@ -1,0 +1,32 @@
+package com.mongmong.namo.presentation.config
+
+import android.util.Log
+import com.google.firebase.remoteconfig.FirebaseRemoteConfig
+import com.google.firebase.remoteconfig.FirebaseRemoteConfigSettings
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class RemoteConfigWrapper @Inject constructor() {
+    private val remoteConfig: FirebaseRemoteConfig by lazy{
+        FirebaseRemoteConfig.getInstance().apply {
+            val configSettings = FirebaseRemoteConfigSettings.Builder()
+                .build()
+            setConfigSettingsAsync(configSettings)
+
+        }
+    }
+
+    fun fetchAndActivateConfig(): String {
+        remoteConfig.fetchAndActivate().addOnCompleteListener{ task ->
+            val updated = task.result
+            if (task.isSuccessful){
+                val updated = task.result
+                Log.d("TAG","Config params updated success: $updated")
+            } else {
+                Log.d("TAG", "Config params updated failed: $updated")
+            }
+        }
+        return remoteConfig.getString("ios_baseurl") + "/"
+    }
+}

--- a/app/src/main/java/com/mongmong/namo/presentation/config/XAccessTokenInterceptor.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/config/XAccessTokenInterceptor.kt
@@ -1,16 +1,12 @@
 package com.mongmong.namo.presentation.config
 
 import android.util.Log
-import com.mongmong.namo.data.remote.AuthApiService
+import com.mongmong.namo.data.remote.AnonymousApiService
+import com.mongmong.namo.data.remote.ReissuanceApiService
+import com.mongmong.namo.domain.model.TokenBody
 import com.mongmong.namo.presentation.config.ApplicationClass.Companion.X_ACCESS_TOKEN
 import com.mongmong.namo.presentation.config.ApplicationClass.Companion.X_REFRESH_TOKEN
 import com.mongmong.namo.presentation.config.ApplicationClass.Companion.sSharedPreferences
-import com.mongmong.namo.domain.model.RefreshResponse
-import com.mongmong.namo.domain.model.TokenBody
-import com.mongmong.namo.domain.repositories.AuthRepository
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import okhttp3.Interceptor
 import okhttp3.Response
@@ -18,7 +14,7 @@ import java.io.IOException
 import javax.inject.Inject
 
 class XAccessTokenInterceptor @Inject constructor(
-    private val apiService: AuthApiService
+    private val apiService: ReissuanceApiService
 ) : Interceptor {
     @Throws(IOException::class)
     override fun intercept(chain: Interceptor.Chain): Response {

--- a/app/src/main/java/com/mongmong/namo/presentation/di/AppModule.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/di/AppModule.kt
@@ -1,0 +1,21 @@
+package com.mongmong.namo.presentation.di
+
+import android.content.Context
+import com.mongmong.namo.presentation.config.ApplicationClass
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object AppModule {
+
+    @Provides
+    @Singleton
+    fun provideApplication(@ApplicationContext app: Context): ApplicationClass {
+        return app as ApplicationClass
+    }
+}

--- a/app/src/main/java/com/mongmong/namo/presentation/di/ServiceModule.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/di/ServiceModule.kt
@@ -1,8 +1,10 @@
 package com.mongmong.namo.presentation.di
 
+import com.mongmong.namo.data.remote.AnonymousApiService
 import com.mongmong.namo.data.remote.CategoryApiService
 import com.mongmong.namo.data.remote.DiaryApiService
 import com.mongmong.namo.data.remote.AuthApiService
+import com.mongmong.namo.data.remote.ReissuanceApiService
 import com.mongmong.namo.data.remote.group.GroupApiService
 import com.mongmong.namo.data.remote.group.GroupDiaryApiService
 import com.mongmong.namo.data.remote.group.GroupScheduleApiService
@@ -19,11 +21,23 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 object ServiceModule {
-    /** 인증 */
+    /** 익명 (로그인, 토큰 재발급) */
     @Provides
     @Singleton
-    fun provideLoginService(@NetworkModule.ReissuanceRetrofit retrofit: Retrofit) : AuthApiService =
+    fun provideAnonymousService(@NetworkModule.AnonymousRetrofit retrofit: Retrofit) : AnonymousApiService =
+        retrofit.create(AnonymousApiService::class.java)
+
+    /** 인증 (로그아웃, 회원탈퇴) */
+    @Provides
+    @Singleton
+    fun provideAuthService(@NetworkModule.BasicRetrofit retrofit: Retrofit) : AuthApiService =
         retrofit.create(AuthApiService::class.java)
+
+    /** 토큰 재발급 (추후 삭제 예정) */
+    @Provides
+    @Singleton
+    fun provideReissuanceService(@NetworkModule.ReissuanceRetrofit retrofit: Retrofit) : ReissuanceApiService =
+        retrofit.create(ReissuanceApiService::class.java)
 
     /** 약관 */
     @Provides

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/login/AuthViewModel.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/login/AuthViewModel.kt
@@ -74,9 +74,9 @@ class AuthViewModel @Inject constructor(
         Log.d("SdkInfo", "quit sdk: $platform")
         viewModelScope.launch {
             val isSuccess = if (platform == LoginPlatform.KAKAO.platformName) { // 카카오
-                repository.postKakaoQuit(getBearerToken())
+                repository.postKakaoQuit()
             } else { // 네이버
-                repository.postNaverQuit(getBearerToken())
+                repository.postNaverQuit()
             }
             if (isSuccess) {
                 _isQuitComplete.postValue(true)


### PR DESCRIPTION
## Related Issue
- #278

## Type of change
<!-- 작업의 종류를 선택해주세요. -->
- [ ] Feature : 새로운 기능 추가
- [ ] Bug fix : 버그 수정
- [x] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [ ] Style : 코드 스타일 및 포맷팅 작업
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## PR Desciption
> 변경 사항 설명
- RemoteConfigWrapper를 사용해서 firebase remoteConfig를 받아옴

### 위 과정 중에 모듈 수정
- AuthApiService 및 기타 ApiService들 : 헤더와 403 로직이 포함된 인터셉터사용
- AnonymousApiService : 익명 서비스(로그인), 인터셉터 사용x (헤더x)
- ReissuanceApiService: 토큰 재발급 api만 사용. 헤더만 포함된 인터셉터사용. 추후 토큰 재발급 api 수정 후 삭제예정

## Requirements for Reviewer
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

-

## PR Log

> PR 작업하면서 고민했던 내용, 해결한 내용, 고민 중인 내용 등

### 새롭게 배운 것

- 

### 고민 중인 사항

- 

## 첨부 자료

-
