### PR TITLE
[Feat/318] 모임 일정 방장/참석자 구분

### DIFF
--- a/app/src/main/java/com/mongmong/namo/presentation/ui/community/moim/schedule/MoimScheduleActivity.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/community/moim/schedule/MoimScheduleActivity.kt
@@ -21,8 +21,6 @@ import androidx.activity.viewModels
 import androidx.constraintlayout.motion.widget.MotionLayout
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
-import com.bumptech.glide.Glide
-import com.bumptech.glide.request.RequestOptions
 import com.google.android.flexbox.FlexDirection
 import com.google.android.flexbox.FlexWrap
 import com.google.android.flexbox.FlexboxLayoutManager
@@ -184,7 +182,7 @@ class MoimScheduleActivity : BaseActivity<ActivityMoimScheduleBinding>(R.layout.
 
     /** 모임 일정 수정 */
     private fun editSchedule() {
-        viewModel.editMoimSchedule()
+        viewModel.onClickEditButton()
     }
 
     /** 모임 일정 삭제 */

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/community/moim/schedule/MoimScheduleActivity.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/community/moim/schedule/MoimScheduleActivity.kt
@@ -199,7 +199,13 @@ class MoimScheduleActivity : BaseActivity<ActivityMoimScheduleBinding>(R.layout.
                 setContent()
             }
             if (schedule.participants.isNotEmpty()) {
-                setParticipantAdapter()
+                 setParticipantAdapter()
+            }
+        }
+
+        viewModel.isCurrentUserOwner.observe(this) { isOwner ->
+            if (isOwner) {
+                participantAdapter.updateIsOwner(isOwner)
             }
         }
 
@@ -353,6 +359,7 @@ class MoimScheduleActivity : BaseActivity<ActivityMoimScheduleBinding>(R.layout.
                 flexDirection = FlexDirection.ROW
             }
         }
+        Log.d("MoimScheduleAct", "isOwner: ${viewModel.isCurrentUserOwner.value!!}")
     }
 
     //TODO: 게스트 리사이클러뷰 연결

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/community/moim/schedule/MoimScheduleViewModel.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/community/moim/schedule/MoimScheduleViewModel.kt
@@ -73,8 +73,7 @@ class MoimScheduleViewModel @Inject constructor(
     }
 
     /** 모임 일정 수정 */
-    //TODO: 방장만 편집 가능
-    fun editMoimSchedule() {
+    private fun editMoimSchedule() { // 방장만 편집 가능
         viewModelScope.launch {
             uploadImageToServer(_moimSchedule.value?.coverImg)
 
@@ -100,13 +99,17 @@ class MoimScheduleViewModel @Inject constructor(
     }
 
     /** 모임 일정 프로필 변경 */
-    //TODO: userId를 통해 사용자의 방장 여부를 판별 후 연동 필요
-    fun editMoimScheduleProfile() {
+    private fun editMoimScheduleProfile() {
         viewModelScope.launch {
-            repository.editMoimScheduleProfile(
-                _moimSchedule.value!!.moimId,
-                _moimSchedule.value!!.title,
-                _moimSchedule.value!!.coverImg)
+            uploadImageToServer(_moimSchedule.value?.coverImg)
+
+            _successState.value = SuccessState(
+                SuccessType.EDIT,
+                repository.editMoimScheduleProfile(
+                    _moimSchedule.value!!.moimId,
+                    _moimSchedule.value!!.title,
+                    _moimSchedule.value!!.coverImg)
+            )
         }
     }
 
@@ -179,6 +182,14 @@ class MoimScheduleViewModel @Inject constructor(
 
     fun updatePrevClickedPicker(clicked: TextView?) {
         _prevClickedPicker.value = clicked
+    }
+
+    fun onClickEditButton() {
+        if (_isCurrentUserOwner.value == true) { // 모임 일정 편집
+            editMoimSchedule()
+        } else { // 모임 일정 프로필 수정
+            editMoimScheduleProfile()
+        }
     }
 
     fun isCreateMode() = _moimSchedule.value!!.moimId == 0L

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/community/moim/schedule/MoimScheduleViewModel.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/community/moim/schedule/MoimScheduleViewModel.kt
@@ -1,6 +1,7 @@
 package com.mongmong.namo.presentation.ui.community.moim.schedule
 
 import android.net.Uri
+import android.util.Log
 import android.widget.TextView
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
@@ -12,10 +13,13 @@ import com.mongmong.namo.domain.model.Participant
 import com.mongmong.namo.domain.model.SchedulePeriod
 import com.mongmong.namo.domain.repositories.ScheduleRepository
 import com.mongmong.namo.domain.usecases.UploadImageToS3UseCase
+import com.mongmong.namo.presentation.config.ApplicationClass.Companion.dsManager
 import com.mongmong.namo.presentation.state.SuccessState
 import com.mongmong.namo.presentation.state.SuccessType
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import org.joda.time.LocalDateTime
 import javax.inject.Inject
 
@@ -26,6 +30,9 @@ class MoimScheduleViewModel @Inject constructor(
 ) : ViewModel() {
     private val _moimSchedule = MutableLiveData<MoimScheduleDetail>()
     val moimSchedule: LiveData<MoimScheduleDetail> = _moimSchedule
+
+    private val _isCurrentUserOwner = MutableLiveData<Boolean>(false) // 로그인 한 유저가 모임의 방장인지
+    val isCurrentUserOwner: LiveData<Boolean> = _isCurrentUserOwner
 
     private val _prevClickedPicker = MutableLiveData<TextView?>()
     var prevClickedPicker: LiveData<TextView?> = _prevClickedPicker
@@ -42,11 +49,12 @@ class MoimScheduleViewModel @Inject constructor(
     private val _successState = MutableLiveData<SuccessState>()
     var successState: LiveData<SuccessState> = _successState
 
-    /** 모임 일정 조회 */
+    /** 모임 일정 상세 조회 */
     private fun getMoimSchedule(moimScheduleId: Long) {
         viewModelScope.launch {
             _moimSchedule.value = repository.getMoimScheduleDetail(moimScheduleId)
             getGuestInvitationLink()
+            checkIsCurrentUserOwner() // 현재 로그인 한 유저가 모임의 방장인지를 확인
         }
     }
 
@@ -106,6 +114,12 @@ class MoimScheduleViewModel @Inject constructor(
         viewModelScope.launch {
             guestInvitationLink = repository.getGuestInvitaionLink(_moimSchedule.value!!.moimId)
         }
+    }
+
+    private fun checkIsCurrentUserOwner() {
+        val myInfo = _moimSchedule.value!!.participants.find { it.userId == getMyUserId() }
+        Log.d("MoimScheduleVM", "myUserId: ${getMyUserId()}, isOwner: ${myInfo?.isOwner}")
+        _isCurrentUserOwner.value = myInfo?.isOwner
     }
 
     private suspend fun uploadImageToServer(imageUri: String?) {
@@ -185,6 +199,11 @@ class MoimScheduleViewModel @Inject constructor(
 //            )
 //        }
         return null
+    }
+
+    // 저장된 userId 가져오기
+    private fun getMyUserId(): Long = runBlocking {
+        dsManager.getUserId().first() ?: 0L
     }
 
     companion object {

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/community/moim/schedule/adapter/MoimParticipantRVAdapter.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/community/moim/schedule/adapter/MoimParticipantRVAdapter.kt
@@ -1,5 +1,6 @@
 package com.mongmong.namo.presentation.ui.community.moim.schedule.adapter
 
+import android.annotation.SuppressLint
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
@@ -7,6 +8,14 @@ import com.mongmong.namo.databinding.ItemMoimParticipantBinding
 import com.mongmong.namo.domain.model.Participant
 
 class MoimParticipantRVAdapter(private val participantList : List<Participant>) : RecyclerView.Adapter<MoimParticipantRVAdapter.ViewHolder>() {
+
+    var isOwner: Boolean = false
+
+    @SuppressLint("NotifyDataSetChanged")
+    fun updateIsOwner(isOwner: Boolean) {
+        this.isOwner = isOwner
+        notifyDataSetChanged()
+    }
 
     override fun onCreateViewHolder(
         parent: ViewGroup,
@@ -26,6 +35,7 @@ class MoimParticipantRVAdapter(private val participantList : List<Participant>) 
     inner class ViewHolder(val binding: ItemMoimParticipantBinding) : RecyclerView.ViewHolder(binding.root) {
         fun bind(participant : Participant) {
             binding.participant = participant
+            binding.isCurrentUserOwner = isOwner
         }
     }
 }

--- a/app/src/main/java/com/mongmong/namo/presentation/utils/BindingAdapters.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/utils/BindingAdapters.kt
@@ -7,6 +7,7 @@ import android.view.View
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.annotation.ColorInt
+import androidx.appcompat.widget.AppCompatTextView
 import androidx.core.content.ContextCompat
 import androidx.databinding.BindingAdapter
 import androidx.lifecycle.LiveData
@@ -32,6 +33,22 @@ object BindingAdapters {
             else -> CategoryColor.DEFAULT_PALETTE_COLOR1.hexColor
         }
         view.backgroundTintList = ColorStateList.valueOf(Color.parseColor(hexColor))
+    }
+
+    @JvmStatic
+    @BindingAdapter("drawableTintColor")
+    fun setDrawableTintColor(view: AppCompatTextView, color: Int) {
+        // TextView의 drawableEnd를 가져옴
+        val drawables = view.compoundDrawablesRelative
+        val drawableEnd = drawables[2] // drawableEnd는 배열의 세 번째 요소
+
+        drawableEnd?.let {
+            // 전달된 color 값을 사용하여 tint 적용
+            it.setTint(color)
+            view.setCompoundDrawablesRelativeWithIntrinsicBounds(
+                drawables[0], drawables[1], it, drawables[3]
+            )
+        }
     }
 
     @JvmStatic

--- a/app/src/main/res/layout/activity_moim_schedule.xml
+++ b/app/src/main/res/layout/activity_moim_schedule.xml
@@ -354,8 +354,11 @@
                         android:layout_height="wrap_content"
                         android:layout_marginTop="25dp"
                         android:paddingVertical="3dp"
+                        android:clickable="@{viewModel.isCurrentUserOwner ? true : false}"
+                        android:textColor="@{viewModel.isCurrentUserOwner ? @color/main_text : @color/text_unselected}"
+                        android:text="@string/moim_schedule_do_friend_invite"
+                        app:drawableTintColor="@{viewModel.isCurrentUserOwner ? @color/main_text : @color/text_unselected}"
                         android:drawableEnd="@drawable/ic_arrow_right"
-                        android:text="@string/moim_schedule_add_participant"
                         style="@style/content_bold"/>
 
                     <androidx.recyclerview.widget.RecyclerView
@@ -374,8 +377,11 @@
                         android:layout_height="wrap_content"
                         android:layout_marginTop="25dp"
                         android:paddingVertical="3dp"
+                        android:clickable="@{viewModel.isCurrentUserOwner ? true : false}"
                         android:visibility="@{viewModel.moimSchedule.moimId == 0L ? View.GONE : View.VISIBLE }"
                         android:drawableEnd="@drawable/ic_arrow_right"
+                        app:drawableTintColor="@{viewModel.isCurrentUserOwner ? @color/main_text : @color/text_unselected}"
+                        android:textColor="@{viewModel.isCurrentUserOwner ? @color/main_text : @color/text_unselected}"
                         android:text="@string/moim_schedule_add_guest"
                         style="@style/content_bold"/>
 

--- a/app/src/main/res/layout/item_moim_participant.xml
+++ b/app/src/main/res/layout/item_moim_participant.xml
@@ -7,6 +7,9 @@
         <import type="com.mongmong.namo.presentation.config.CategoryColor"/>
         <import type="android.view.View"/>
         <variable
+            name="isCurrentUserOwner"
+            type="Boolean" />
+        <variable
             name="participant"
             type="com.mongmong.namo.domain.model.Participant" />
     </data>
@@ -69,7 +72,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="8dp"
                 android:src="@drawable/ic_close"
-                android:visibility="@{participant.isOwner ? View.GONE : View.VISIBLE }"/>
+                android:visibility="@{!isCurrentUserOwner ? View.GONE : ( participant.isOwner ? View.GONE : View.VISIBLE ) }"/>
 
         </LinearLayout>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -197,7 +197,6 @@
     <string name="moim_schedule_title_hint">내 모임</string>
     <string name="moim_schedule_new_moim_start">새 모임 시작하기</string>
     <string name="moim_schedule_look_invite_friend_schedule">초대한 친구 일정 보기</string>
-    <string name="moim_schedule_add_participant">친구 추가하기</string>
     <string name="moim_schedule_do_friend_invite">친구 초대하기</string>
     <string name="moim_schedule_invite_friend">초대한 친구</string>
     <string name="moim_schedule_invite_friend_empty">아직 초대한 친구가 없습니다.</string>


### PR DESCRIPTION
## Related Issue
- #318

## Type of change
<!-- 작업의 종류를 선택해주세요. -->
- [x] Feature : 새로운 기능 추가
- [ ] Bug fix : 버그 수정
- [ ] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [ ] Style : 코드 스타일 및 포맷팅 작업
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## PR Desciption
> 변경 사항 설명

모임 일정 방장일 떄와 참석자일 때 화면과 사용하는 API가 조금 달라서 해당 부분을 작업했습니다.
![image](https://github.com/user-attachments/assets/d98f9e80-74a0-4410-babd-c137b0885f96)  방장일 때 | ![image](https://github.com/user-attachments/assets/f0af4d2e-02b4-4aed-bcdd-cb54fee2193d) 참석자일 때
---|---|

## Requirements for Reviewer
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

-

## PR Log

> PR 작업하면서 고민했던 내용, 해결한 내용, 고민 중인 내용 등

### 새롭게 배운 것

- 

### 고민 중인 사항

- 

## 첨부 자료

-
