### PR TITLE
[Feat/348] 보관함 캘린더 디자인 변경

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,10 +4,10 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2024-10-29T09:50:21.570709Z">
+        <DropdownSelection timestamp="2024-12-14T06:58:16.787099Z">
           <Target type="DEFAULT_BOOT">
             <handle>
-              <DeviceId pluginId="LocalEmulator" identifier="path=/Users/nahyun/.android/avd/Pixel_4_API_30.avd" />
+              <DeviceId pluginId="LocalEmulator" identifier="path=/Users/sindong-won/.android/avd/Pixel_4_API_33.avd" />
             </handle>
           </Target>
         </DropdownSelection>

--- a/.idea/other.xml
+++ b/.idea/other.xml
@@ -26,6 +26,17 @@
           <option name="screenY" value="2160" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="Lenovo" />
+          <option name="codename" value="TB370FU" />
+          <option name="id" value="TB370FU" />
+          <option name="manufacturer" value="Lenovo" />
+          <option name="name" value="Tab P12" />
+          <option name="screenDensity" value="340" />
+          <option name="screenX" value="1840" />
+          <option name="screenY" value="2944" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
           <option name="api" value="31" />
           <option name="brand" value="samsung" />
           <option name="codename" value="a51" />
@@ -246,6 +257,17 @@
           <option name="screenY" value="2176" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="q6q" />
+          <option name="id" value="q6q" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy Z Fold6" />
+          <option name="screenDensity" value="420" />
+          <option name="screenX" value="1856" />
+          <option name="screenY" value="2160" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
           <option name="api" value="30" />
           <option name="brand" value="google" />
           <option name="codename" value="r11" />
@@ -300,17 +322,6 @@
           <option name="screenDensity" value="420" />
           <option name="screenX" value="1080" />
           <option name="screenY" value="2424" />
-        </PersistentDeviceSelectionData>
-        <PersistentDeviceSelectionData>
-          <option name="api" value="29" />
-          <option name="brand" value="samsung" />
-          <option name="codename" value="x1q" />
-          <option name="id" value="x1q" />
-          <option name="manufacturer" value="Samsung" />
-          <option name="name" value="Galaxy S20" />
-          <option name="screenDensity" value="480" />
-          <option name="screenX" value="1440" />
-          <option name="screenY" value="3200" />
         </PersistentDeviceSelectionData>
       </list>
     </option>

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/home/diary/DiaryCalendarFragment.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/home/diary/DiaryCalendarFragment.kt
@@ -309,9 +309,4 @@ class DiaryCalendarFragment :
             viewModel.toggleBottomSheetState()
         }
     }
-
-    companion object {
-        const val INDICATOR_FIRST = 7
-        const val INDICATOR_LAST = 21
-    }
 }

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/home/diary/DiaryCalendarFragment.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/home/diary/DiaryCalendarFragment.kt
@@ -44,7 +44,7 @@ class DiaryCalendarFragment :
     private lateinit var personalDiaryAdapter: PersonalDiaryRVAdapter
     private lateinit var moimDiaryAdapter: MoimDiaryRVAdapter
     private var isInitialLoad = true
-    private var lastDisplayedMonth: Int? = null // 마지막으로 표시된 월을 저장하는 변수
+    private var lastDisplayedMonth: String? = null // 마지막으로 표시된 월을 저장
     private val fetchedMonths = mutableSetOf<String>() // 이미 요청한 월을 저장하는 집합
 
     override fun setup() {
@@ -149,6 +149,10 @@ class DiaryCalendarFragment :
         // 어댑터에 중앙에 보이는 달 전달
         centerItem?.let {
             val currentMonth = it.toYearMonth()
+            if (currentMonth != lastDisplayedMonth) {
+                lastDisplayedMonth = currentMonth
+                showMonthSnackBar(it.year, it.month + 1) // 스낵바 띄우기
+            }
             calendarAdapter.updateVisibleMonth(currentMonth)
         }
     }
@@ -165,28 +169,6 @@ class DiaryCalendarFragment :
         val isBottomSheetOpened = viewModel.isBottomSheetOpened.value ?: false
 
         viewModel.setReturnBtnVisible(!isAtBottom && !isBottomSheetOpened)
-    }
-
-    private fun checkFirstDay(recyclerView: RecyclerView) {
-        val layoutManager = recyclerView.layoutManager as GridLayoutManager
-        val firstVisiblePosition = layoutManager.findFirstVisibleItemPosition()
-        val lastVisiblePosition = firstVisiblePosition + INDICATOR_LAST
-
-        for (position in firstVisiblePosition..lastVisiblePosition) {
-            val calendarDay = calendarAdapter.getItemAtPosition(position)
-            if (calendarDay != null) {
-                if (calendarDay.date == 1) {
-                    val currentMonth = calendarDay.month + 1
-
-                    // 달이 바뀐 경우에만 스낵바
-                    if (lastDisplayedMonth == null || lastDisplayedMonth != currentMonth) {
-                        lastDisplayedMonth = currentMonth
-                        showMonthSnackBar(calendarDay.year, currentMonth)
-                    }
-                    break
-                }
-            }
-        }
     }
 
     private fun setDiaryIndicator(recyclerView: RecyclerView) {

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/home/diary/adapter/DiaryCalendarAdapter.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/home/diary/adapter/DiaryCalendarAdapter.kt
@@ -14,7 +14,6 @@ import com.mongmong.namo.domain.model.CalendarDate
 import com.mongmong.namo.domain.model.CalendarDay
 import com.mongmong.namo.domain.model.ScheduleType
 import com.mongmong.namo.presentation.utils.converter.DiaryDateConverter.toYearMonth
-import java.util.Calendar
 
 class DiaryCalendarAdapter(
     private val recyclerView: RecyclerView,
@@ -30,7 +29,6 @@ class DiaryCalendarAdapter(
 
     fun updateDiaryDates(yearMonth: String, diaryDates: Set<CalendarDate>) {
         this.diaryDates[yearMonth] = diaryDates
-
         items.forEachIndexed { index, calendarDay ->
             if (calendarDay.toYearMonth() == yearMonth) {
                 notifyItemChanged(index)
@@ -46,31 +44,23 @@ class DiaryCalendarAdapter(
     }
 
     fun updateBottomSheetState(isOpened: Boolean) {
-        if (isBottomSheetOpen == isOpened) return
+        if (isBottomSheetOpen == isOpened || itemCount == 0) return
         isBottomSheetOpen = isOpened
 
-        // 화면에 보이는 아이템들의 위치를 가져옴
-        val layoutManager = recyclerView.layoutManager ?: return
-        val firstVisibleItemPosition =
-            (layoutManager as GridLayoutManager).findFirstVisibleItemPosition()
+        val layoutManager = recyclerView.layoutManager as? GridLayoutManager ?: return
+        val firstVisibleItemPosition = layoutManager.findFirstVisibleItemPosition()
         val lastVisibleItemPosition = layoutManager.findLastVisibleItemPosition()
 
-        // 보이는 아이템은 애니메이션 적용
         for (i in firstVisibleItemPosition..lastVisibleItemPosition) {
             val viewHolder = recyclerView.findViewHolderForAdapterPosition(i) as? ViewHolder
             viewHolder?.updateItemWithAnimate(isOpened)
         }
 
-        // 보이지 않는 아이템은 notify로 높이 변경
-        if (firstVisibleItemPosition > 0) {
-            for (i in 0 until firstVisibleItemPosition) {
-                notifyItemChanged(i, isOpened)
-            }
+        for (i in 0 until firstVisibleItemPosition) {
+            notifyItemChanged(i, isOpened)
         }
-        if (lastVisibleItemPosition < itemCount - 1) {
-            for (i in lastVisibleItemPosition + 1 until itemCount) {
-                notifyItemChanged(i, isOpened)
-            }
+        for (i in lastVisibleItemPosition + 1 until itemCount) {
+            notifyItemChanged(i, isOpened)
         }
     }
 
@@ -82,8 +72,6 @@ class DiaryCalendarAdapter(
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         val item = items[position]
         holder.bind(item)
-
-        // 현재 달 상태에 따라 아이템을 업데이트
         holder.updateItem(isBottomSheetOpen)
     }
 
@@ -103,13 +91,11 @@ class DiaryCalendarAdapter(
         }
     }
 
-
+    override fun getItemCount(): Int = items.size
 
     fun getItemAtPosition(position: Int): CalendarDay? {
         return if (position in items.indices) items[position] else null
     }
-
-    override fun getItemCount(): Int = items.size
 
     inner class ViewHolder(val binding: ItemDiaryCalendarDateBinding) :
         RecyclerView.ViewHolder(binding.root) {
@@ -202,7 +188,6 @@ class DiaryCalendarAdapter(
                 }
             }
 
-            // 새로운 날짜 선택
             selectedDate = newDate
             selectedDateView = newDateView
             newDateView.setTextColor(newDateView.context.getColor(R.color.main))
@@ -212,7 +197,6 @@ class DiaryCalendarAdapter(
                 notifyItemChanged(newIndex, PAYLOAD_SELECT)
             }
         }
-
     }
 
     interface OnCalendarListener {
@@ -230,5 +214,4 @@ class DiaryCalendarAdapter(
         const val PAYLOAD_SELECT = "select"
         const val PAYLOAD_DESELECT = "deselect"
     }
-
 }

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/home/diary/adapter/DiaryCalendarAdapter.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/home/diary/adapter/DiaryCalendarAdapter.kt
@@ -156,9 +156,6 @@ class DiaryCalendarAdapter(
                 this.height = height
             }
             binding.root.requestLayout()
-
-            val indicatorImage = if (isOpening) R.drawable.ic_archive_diary_small else R.drawable.ic_archive_diary
-            binding.diaryCalendarHasDiaryIndicatorIv.setImageResource(indicatorImage)
         }
 
         fun updateItemWithAnimate(isOpening: Boolean) {
@@ -174,9 +171,6 @@ class DiaryCalendarAdapter(
             }
             valueAnimator.duration = ANIMATION_DURATION
             valueAnimator.start()
-
-            val indicatorImage = if (isOpening) R.drawable.ic_archive_diary_small else R.drawable.ic_archive_diary
-            binding.diaryCalendarHasDiaryIndicatorIv.setImageResource(indicatorImage)
         }
 
         private fun updateSelectedDateView(newDateView: TextView, newDate: CalendarDay) {

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/home/diary/adapter/DiaryCalendarAdapter.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/home/diary/adapter/DiaryCalendarAdapter.kt
@@ -1,6 +1,7 @@
 package com.mongmong.namo.presentation.ui.home.diary.adapter
 
 import android.animation.ValueAnimator
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -13,6 +14,7 @@ import com.mongmong.namo.domain.model.CalendarDate
 import com.mongmong.namo.domain.model.CalendarDay
 import com.mongmong.namo.domain.model.ScheduleType
 import com.mongmong.namo.presentation.utils.converter.DiaryDateConverter.toYearMonth
+import java.util.Calendar
 
 class DiaryCalendarAdapter(
     private val recyclerView: RecyclerView,
@@ -20,35 +22,54 @@ class DiaryCalendarAdapter(
     private val listener: OnCalendarListener
 ) : RecyclerView.Adapter<DiaryCalendarAdapter.ViewHolder>() {
 
-    private var diaryDates: MutableMap<String, Set<CalendarDate>> = mutableMapOf()
-    private var isBottomSheetOpen: Boolean = false
-    private var selectedDate: CalendarDay? = null // 선택된 날짜
-    private var visibleMonth: String? = null
+    private var diaryDates: MutableMap<String, Set<CalendarDate>> = mutableMapOf() // "yyyy-MM": [기록된 날짜들]
+    private var isBottomSheetOpen: Boolean = false // 바텀시트 상태
+    private var selectedDateView: TextView? = null  // 선택된 날짜의 TextView
+    private var selectedDate: CalendarDay? = null  // 선택된 날짜
+    private var visibleMonth: String? = null // 현재 화면 중앙의 달 ("yyyy-MM")
 
     fun updateDiaryDates(yearMonth: String, diaryDates: Set<CalendarDate>) {
         this.diaryDates[yearMonth] = diaryDates
+
         items.forEachIndexed { index, calendarDay ->
-            if (calendarDay.toYearMonth() == yearMonth) notifyItemChanged(index)
+            if (calendarDay.toYearMonth() == yearMonth) {
+                notifyItemChanged(index)
+            }
         }
     }
 
     fun updateVisibleMonth(visibleMonth: String) {
         if (this.visibleMonth != visibleMonth) {
             this.visibleMonth = visibleMonth
-            notifyDataSetChanged()
+            notifyDataSetChanged() // 현재 보이는 달이 바뀌었을 때 전체 갱신
         }
     }
 
     fun updateBottomSheetState(isOpened: Boolean) {
-        if (isBottomSheetOpen != isOpened) {
-            isBottomSheetOpen = isOpened
-            val layoutManager = recyclerView.layoutManager as? GridLayoutManager ?: return
-            val firstVisibleItemPosition = layoutManager.findFirstVisibleItemPosition()
-            val lastVisibleItemPosition = layoutManager.findLastVisibleItemPosition()
+        if (isBottomSheetOpen == isOpened) return
+        isBottomSheetOpen = isOpened
 
-            for (i in firstVisibleItemPosition..lastVisibleItemPosition) {
-                (recyclerView.findViewHolderForAdapterPosition(i) as? ViewHolder)
-                    ?.updateItemWithAnimate(isOpened)
+        // 화면에 보이는 아이템들의 위치를 가져옴
+        val layoutManager = recyclerView.layoutManager ?: return
+        val firstVisibleItemPosition =
+            (layoutManager as GridLayoutManager).findFirstVisibleItemPosition()
+        val lastVisibleItemPosition = layoutManager.findLastVisibleItemPosition()
+
+        // 보이는 아이템은 애니메이션 적용
+        for (i in firstVisibleItemPosition..lastVisibleItemPosition) {
+            val viewHolder = recyclerView.findViewHolderForAdapterPosition(i) as? ViewHolder
+            viewHolder?.updateItemWithAnimate(isOpened)
+        }
+
+        // 보이지 않는 아이템은 notify로 높이 변경
+        if (firstVisibleItemPosition > 0) {
+            for (i in 0 until firstVisibleItemPosition) {
+                notifyItemChanged(i, isOpened)
+            }
+        }
+        if (lastVisibleItemPosition < itemCount - 1) {
+            for (i in lastVisibleItemPosition + 1 until itemCount) {
+                notifyItemChanged(i, isOpened)
             }
         }
     }
@@ -60,10 +81,29 @@ class DiaryCalendarAdapter(
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         val item = items[position]
-        val isSelected = selectedDate?.isSameDate(item) == true
-        holder.bind(item, isSelected)
+        holder.bind(item)
+
+        // 현재 달 상태에 따라 아이템을 업데이트
         holder.updateItem(isBottomSheetOpen)
     }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int, payloads: MutableList<Any>) {
+        if (payloads.isNotEmpty()) {
+            when (payloads[0]) {
+                PAYLOAD_SELECT -> holder.setSelected(true)
+                PAYLOAD_DESELECT -> holder.setSelected(false)
+                else -> {
+                    Log.e("DiaryCalendarAdapter", "Unexpected payload: ${payloads[0]}")
+                    holder.bind(items[position])
+                }
+            }
+        } else {
+            Log.e("DiaryCalendarAdapter", "Unexpected payload2")
+            holder.bind(items[position])
+        }
+    }
+
+
 
     fun getItemAtPosition(position: Int): CalendarDay? {
         return if (position in items.indices) items[position] else null
@@ -74,11 +114,11 @@ class DiaryCalendarAdapter(
     inner class ViewHolder(val binding: ItemDiaryCalendarDateBinding) :
         RecyclerView.ViewHolder(binding.root) {
 
-        fun bind(calendarDay: CalendarDay, isSelected: Boolean) {
+        fun bind(calendarDay: CalendarDay) {
             binding.calendarDay = calendarDay
 
-            val dateType = diaryDates[calendarDay.toYearMonth()]
-                ?.find { it.date == calendarDay.date.toString() }?.type
+            // Indicator 설정
+            val dateType = diaryDates[calendarDay.toYearMonth()]?.find { it.date == calendarDay.date.toString() }?.type
             binding.diaryCalendarHasDiaryIndicatorIv.visibility = if (dateType != null) View.VISIBLE else View.GONE
 
             val color = when (dateType) {
@@ -86,58 +126,93 @@ class DiaryCalendarAdapter(
                 ScheduleType.MOIM -> R.color.main
                 else -> null
             }
+
             color?.let {
                 binding.diaryCalendarHasDiaryIndicatorIv.setColorFilter(
-                    binding.root.context.getColor(it), android.graphics.PorterDuff.Mode.SRC_IN
+                    binding.root.context.getColor(it),
+                    android.graphics.PorterDuff.Mode.SRC_IN
                 )
             }
 
+            // 텍스트 색상 설정
             binding.diaryCalendarDateTv.setTextColor(
                 binding.root.context.getColor(
                     when {
-                        isSelected -> R.color.main
-                        calendarDay.toYearMonth() == visibleMonth -> R.color.main_text
-                        else -> R.color.text_placeholder
+                        calendarDay.isSameDate(selectedDate) -> R.color.main // 선택된 날짜
+                        calendarDay.toYearMonth() == visibleMonth -> R.color.main_text // 현재 달
+                        else -> R.color.text_placeholder // 다른 달
                     }
                 )
             )
-            binding.diaryCalendarDateTv.invalidate()
 
+            // 클릭 리스너 설정
             binding.root.setOnClickListener {
-                updateSelectedDate(calendarDay)
+                updateSelectedDateView(binding.diaryCalendarDateTv, calendarDay)
                 listener.onCalendarDayClick(calendarDay)
             }
+
+            // 아이템 높이 설정
+            val height = dpToPx(if (isBottomSheetOpen) OPEN_HEIGHT else CLOSE_HEIGHT, binding.root.context)
+            binding.root.layoutParams = binding.root.layoutParams.apply {
+                this.height = height
+            }
+            binding.root.requestLayout()
+        }
+
+        fun setSelected(isSelected: Boolean) {
+            binding.diaryCalendarDateTv.setTextColor(
+                binding.root.context.getColor(
+                    if (isSelected) R.color.main
+                    else if (binding.calendarDay?.toYearMonth() == visibleMonth) R.color.main_text
+                    else R.color.text_placeholder
+                )
+            )
         }
 
         fun updateItem(isOpening: Boolean) {
+            // 높이 조정
             val height = dpToPx(if (isOpening) OPEN_HEIGHT else CLOSE_HEIGHT, binding.root.context)
-            binding.root.layoutParams = binding.root.layoutParams.apply { this.height = height }
+            binding.root.layoutParams = binding.root.layoutParams.apply {
+                this.height = height
+            }
             binding.root.requestLayout()
         }
 
         fun updateItemWithAnimate(isOpening: Boolean) {
+            // 높이 조정
             val fromHeight = binding.root.height
             val toHeight = dpToPx(if (isOpening) OPEN_HEIGHT else CLOSE_HEIGHT, binding.root.context)
-            ValueAnimator.ofInt(fromHeight, toHeight).apply {
-                addUpdateListener { animator ->
-                    binding.root.layoutParams = binding.root.layoutParams.apply {
-                        height = animator.animatedValue as Int
-                    }
+
+            val valueAnimator = ValueAnimator.ofInt(fromHeight, toHeight)
+            valueAnimator.addUpdateListener { animator ->
+                val layoutParams = binding.root.layoutParams
+                layoutParams.height = animator.animatedValue as Int
+                binding.root.layoutParams = layoutParams
+            }
+            valueAnimator.duration = ANIMATION_DURATION
+            valueAnimator.start()
+        }
+
+        private fun updateSelectedDateView(newDateView: TextView, newDate: CalendarDay) {
+            // 이전 선택된 날짜 초기화
+            selectedDate?.let { oldDate ->
+                val oldIndex = items.indexOfFirst { it.isSameDate(oldDate) }
+                if (oldIndex != -1) {
+                    notifyItemChanged(oldIndex, PAYLOAD_DESELECT)
                 }
-                duration = ANIMATION_DURATION
-                start()
+            }
+
+            // 새로운 날짜 선택
+            selectedDate = newDate
+            selectedDateView = newDateView
+            newDateView.setTextColor(newDateView.context.getColor(R.color.main))
+
+            val newIndex = items.indexOfFirst { it.isSameDate(newDate) }
+            if (newIndex != -1) {
+                notifyItemChanged(newIndex, PAYLOAD_SELECT)
             }
         }
-    }
 
-    private fun updateSelectedDate(newDate: CalendarDay) {
-        val oldSelectedPosition = items.indexOfFirst { it.isSameDate(selectedDate) }
-        val newSelectedPosition = items.indexOfFirst { it.isSameDate(newDate) }
-
-        selectedDate = if (selectedDate?.isSameDate(newDate) == true) null else newDate
-
-        if (oldSelectedPosition != -1) notifyItemChanged(oldSelectedPosition)
-        if (newSelectedPosition != -1) notifyItemChanged(newSelectedPosition)
     }
 
     interface OnCalendarListener {
@@ -152,5 +227,8 @@ class DiaryCalendarAdapter(
         const val ANIMATION_DURATION = 170L
         const val OPEN_HEIGHT = 56
         const val CLOSE_HEIGHT = 84
+        const val PAYLOAD_SELECT = "select"
+        const val PAYLOAD_DESELECT = "deselect"
     }
+
 }

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/home/diary/adapter/DiaryCalendarAdapter.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/home/diary/adapter/DiaryCalendarAdapter.kt
@@ -13,7 +13,6 @@ import com.mongmong.namo.domain.model.CalendarDate
 import com.mongmong.namo.domain.model.CalendarDay
 import com.mongmong.namo.domain.model.ScheduleType
 import com.mongmong.namo.presentation.utils.converter.DiaryDateConverter.toYearMonth
-import java.util.Calendar
 
 class DiaryCalendarAdapter(
     private val recyclerView: RecyclerView,
@@ -21,54 +20,35 @@ class DiaryCalendarAdapter(
     private val listener: OnCalendarListener
 ) : RecyclerView.Adapter<DiaryCalendarAdapter.ViewHolder>() {
 
-    private var diaryDates: MutableMap<String, Set<CalendarDate>> = mutableMapOf() // "yyyy-MM": [기록된 날짜들]
-    private var isBottomSheetOpen: Boolean = false // 바텀시트 상태
-    private var selectedDateView: TextView? = null  // 선택된 날짜의 TextView
-    private var selectedDate: CalendarDay? = null  // 선택된 날짜
-    private var visibleMonth: String? = null // 현재 화면 중앙의 달 ("yyyy-MM")
+    private var diaryDates: MutableMap<String, Set<CalendarDate>> = mutableMapOf()
+    private var isBottomSheetOpen: Boolean = false
+    private var selectedDate: CalendarDay? = null // 선택된 날짜
+    private var visibleMonth: String? = null
 
     fun updateDiaryDates(yearMonth: String, diaryDates: Set<CalendarDate>) {
         this.diaryDates[yearMonth] = diaryDates
-
         items.forEachIndexed { index, calendarDay ->
-            if (calendarDay.toYearMonth() == yearMonth) {
-                notifyItemChanged(index)
-            }
+            if (calendarDay.toYearMonth() == yearMonth) notifyItemChanged(index)
         }
     }
 
     fun updateVisibleMonth(visibleMonth: String) {
         if (this.visibleMonth != visibleMonth) {
             this.visibleMonth = visibleMonth
-            notifyDataSetChanged() // 현재 보이는 달이 바뀌었을 때 전체 갱신
+            notifyDataSetChanged()
         }
     }
 
     fun updateBottomSheetState(isOpened: Boolean) {
         if (isBottomSheetOpen != isOpened) {
             isBottomSheetOpen = isOpened
-
-            // 화면에 보이는 아이템들의 위치를 가져옴
-            val layoutManager = recyclerView.layoutManager ?: return
-            val firstVisibleItemPosition = (layoutManager as GridLayoutManager).findFirstVisibleItemPosition()
+            val layoutManager = recyclerView.layoutManager as? GridLayoutManager ?: return
+            val firstVisibleItemPosition = layoutManager.findFirstVisibleItemPosition()
             val lastVisibleItemPosition = layoutManager.findLastVisibleItemPosition()
 
-            // 보이는 아이템은 애니메이션 적용
             for (i in firstVisibleItemPosition..lastVisibleItemPosition) {
-                val viewHolder = recyclerView.findViewHolderForAdapterPosition(i) as? ViewHolder
-                viewHolder?.updateItemWithAnimate(isOpened)
-            }
-
-            // 보이지 않는 아이템은 notify로 높이 변경
-            if (firstVisibleItemPosition > 0) {
-                for (i in 0 until firstVisibleItemPosition) {
-                    notifyItemChanged(i, isOpened)
-                }
-            }
-            if (lastVisibleItemPosition < itemCount - 1) {
-                for (i in lastVisibleItemPosition + 1 until itemCount) {
-                    notifyItemChanged(i, isOpened)
-                }
+                (recyclerView.findViewHolderForAdapterPosition(i) as? ViewHolder)
+                    ?.updateItemWithAnimate(isOpened)
             }
         }
     }
@@ -80,19 +60,9 @@ class DiaryCalendarAdapter(
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         val item = items[position]
-        holder.bind(item)
-
-        // 현재 달 상태에 따라 아이템을 업데이트
+        val isSelected = selectedDate?.isSameDate(item) == true
+        holder.bind(item, isSelected)
         holder.updateItem(isBottomSheetOpen)
-    }
-
-    override fun onBindViewHolder(holder: ViewHolder, position: Int, payloads: MutableList<Any>) {
-        if (payloads.isNotEmpty()) {
-            val isOpened = payloads[0] as Boolean
-            holder.updateItem(isOpened)
-        } else {
-            super.onBindViewHolder(holder, position, payloads)
-        }
     }
 
     fun getItemAtPosition(position: Int): CalendarDay? {
@@ -104,11 +74,11 @@ class DiaryCalendarAdapter(
     inner class ViewHolder(val binding: ItemDiaryCalendarDateBinding) :
         RecyclerView.ViewHolder(binding.root) {
 
-        fun bind(calendarDay: CalendarDay) {
+        fun bind(calendarDay: CalendarDay, isSelected: Boolean) {
             binding.calendarDay = calendarDay
 
-            // Indicator 설정
-            val dateType = diaryDates[calendarDay.toYearMonth()]?.find { it.date == calendarDay.date.toString() }?.type
+            val dateType = diaryDates[calendarDay.toYearMonth()]
+                ?.find { it.date == calendarDay.date.toString() }?.type
             binding.diaryCalendarHasDiaryIndicatorIv.visibility = if (dateType != null) View.VISIBLE else View.GONE
 
             val color = when (dateType) {
@@ -116,86 +86,58 @@ class DiaryCalendarAdapter(
                 ScheduleType.MOIM -> R.color.main
                 else -> null
             }
-
             color?.let {
                 binding.diaryCalendarHasDiaryIndicatorIv.setColorFilter(
-                    binding.root.context.getColor(it),
-                    android.graphics.PorterDuff.Mode.SRC_IN
+                    binding.root.context.getColor(it), android.graphics.PorterDuff.Mode.SRC_IN
                 )
             }
 
-            // 텍스트 색상 설정
             binding.diaryCalendarDateTv.setTextColor(
                 binding.root.context.getColor(
                     when {
-                        calendarDay.isSameDate(selectedDate) -> R.color.main // 선택된 날짜
-                        calendarDay.toYearMonth() == visibleMonth -> R.color.main_text // 현재 달
-                        else -> R.color.text_placeholder // 다른 달
+                        isSelected -> R.color.main
+                        calendarDay.toYearMonth() == visibleMonth -> R.color.main_text
+                        else -> R.color.text_placeholder
                     }
                 )
             )
+            binding.diaryCalendarDateTv.invalidate()
 
-            // 클릭 리스너 설정
             binding.root.setOnClickListener {
-                updateSelectedDateView(binding.diaryCalendarDateTv, calendarDay)
+                updateSelectedDate(calendarDay)
                 listener.onCalendarDayClick(calendarDay)
             }
-
-            // 아이템 높이 설정
-            val height = dpToPx(if (isBottomSheetOpen) OPEN_HEIGHT else CLOSE_HEIGHT, binding.root.context)
-            binding.root.layoutParams = binding.root.layoutParams.apply {
-                this.height = height
-            }
-            binding.root.requestLayout()
         }
 
         fun updateItem(isOpening: Boolean) {
-            // 높이 조정
             val height = dpToPx(if (isOpening) OPEN_HEIGHT else CLOSE_HEIGHT, binding.root.context)
-            binding.root.layoutParams = binding.root.layoutParams.apply {
-                this.height = height
-            }
+            binding.root.layoutParams = binding.root.layoutParams.apply { this.height = height }
             binding.root.requestLayout()
         }
 
         fun updateItemWithAnimate(isOpening: Boolean) {
-            // 높이 조정
             val fromHeight = binding.root.height
             val toHeight = dpToPx(if (isOpening) OPEN_HEIGHT else CLOSE_HEIGHT, binding.root.context)
-
-            val valueAnimator = ValueAnimator.ofInt(fromHeight, toHeight)
-            valueAnimator.addUpdateListener { animator ->
-                val layoutParams = binding.root.layoutParams
-                layoutParams.height = animator.animatedValue as Int
-                binding.root.layoutParams = layoutParams
-            }
-            valueAnimator.duration = ANIMATION_DURATION
-            valueAnimator.start()
-        }
-
-        private fun updateSelectedDateView(newDateView: TextView, newDate: CalendarDay) {
-            // 선택한 날짜를 다시 클릭하면 선택을 해제
-            if (selectedDate?.isSameDate(newDate) == true) {
-                selectedDateView?.setTextColor(
-                    binding.diaryCalendarDateTv.context.getColor(
-                        if (newDate.toYearMonth() == visibleMonth) R.color.main_text else R.color.text_placeholder
-                    )
-                )
-                selectedDate = null
-                selectedDateView = null
-            } else {
-                // 새로운 날짜를 선택
-                selectedDateView?.setTextColor(
-                    binding.diaryCalendarDateTv.context.getColor(
-                        if (selectedDate?.toYearMonth() == visibleMonth) R.color.main_text else R.color.text_placeholder
-                    )
-                )
-                selectedDate = newDate
-                selectedDateView = newDateView.apply {
-                    setTextColor(context.getColor(R.color.main))
+            ValueAnimator.ofInt(fromHeight, toHeight).apply {
+                addUpdateListener { animator ->
+                    binding.root.layoutParams = binding.root.layoutParams.apply {
+                        height = animator.animatedValue as Int
+                    }
                 }
+                duration = ANIMATION_DURATION
+                start()
             }
         }
+    }
+
+    private fun updateSelectedDate(newDate: CalendarDay) {
+        val oldSelectedPosition = items.indexOfFirst { it.isSameDate(selectedDate) }
+        val newSelectedPosition = items.indexOfFirst { it.isSameDate(newDate) }
+
+        selectedDate = if (selectedDate?.isSameDate(newDate) == true) null else newDate
+
+        if (oldSelectedPosition != -1) notifyItemChanged(oldSelectedPosition)
+        if (newSelectedPosition != -1) notifyItemChanged(newSelectedPosition)
     }
 
     interface OnCalendarListener {

--- a/app/src/main/res/layout/item_diary_calendar_date.xml
+++ b/app/src/main/res/layout/item_diary_calendar_date.xml
@@ -31,6 +31,7 @@
             android:visibility="gone"
             android:layout_marginTop="8dp"
             android:layout_marginBottom="13dp"
+            android:src="@drawable/ic_archive_diary_small"
             app:layout_constraintTop_toBottomOf="@id/diary_calendar_date_tv"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"


### PR DESCRIPTION
## Related Issue
- #348 

## Type of change
<!-- 작업의 종류를 선택해주세요. -->
- [x] Feature : 새로운 기능 추가

## PR Desciption
> 변경 사항 설명

https://github.com/user-attachments/assets/7615c5a0-b51a-41a4-9dc4-5bc0e92c65e5


보관함 캘린더 스크롤 시 텍스트 색 변환 로직 추가
- 현재 달 탐색 방식 변경 ( 날짜 아이템 두번째 주 검사 -> 아이템 포지션의 중앙 계산)
- 현재 달만 검은색, 나머지달은 회색

1일 표시 디자인 변경
- 메인 컬러 -> 일반색(검정 or 회색)

기록 아이콘 변경

## Requirements for Reviewer
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

-

## PR Log

> PR 작업하면서 고민했던 내용, 해결한 내용, 고민 중인 내용 등

### 새롭게 배운 것

- 

### 고민 중인 사항

- 

## 첨부 자료

-
