### PR TITLE
[Fix/351] 보관함 필터 없음 오류 처리

### DIFF
--- a/app/src/main/java/com/mongmong/namo/presentation/ui/home/diary/DiaryArchiveFragment.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/home/diary/DiaryArchiveFragment.kt
@@ -1,7 +1,9 @@
 package com.mongmong.namo.presentation.ui.home.diary
 
 import android.content.Intent
+import android.text.InputType
 import android.util.Log
+import android.widget.Toast
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.paging.LoadState
@@ -25,21 +27,6 @@ import java.util.ArrayList
 class DiaryArchiveFragment: BaseFragment<FragmentDiaryArchiveBinding>(R.layout.fragment_diary_archive) {
     private val viewModel: DiaryViewModel by viewModels()
 
-    private fun initClickListener() {
-        binding.diaryArchiveFilter.setOnClickListener {
-            DiaryFilterDialog(viewModel.filter.value).apply {
-                setOnFilterSelectedListener(object : DiaryFilterDialog.OnFilterSelectedListener {
-                    override fun onFilterSelected(filter: FilterType) {
-                        viewModel.setFilter(filter)
-                    }
-                })
-            }.show(parentFragmentManager, "FilterDialog")
-        }
-        binding.diaryArchiveFilterSearchBtn.setOnClickListener {
-            getDiaries()
-        }
-    }
-
     override fun setup() {
         binding.viewModel = viewModel
         initClickListener()
@@ -50,6 +37,33 @@ class DiaryArchiveFragment: BaseFragment<FragmentDiaryArchiveBinding>(R.layout.f
         getDiaries() // 화면이 다시 보일 때 관찰 시작
     }
 
+    private fun initClickListener() {
+        binding.diaryArchiveFilter.setOnClickListener {
+            DiaryFilterDialog(viewModel.filter.value).apply {
+                setOnFilterSelectedListener(object : DiaryFilterDialog.OnFilterSelectedListener {
+                    override fun onFilterSelected(filter: FilterType) {
+                        viewModel.setFilter(filter)
+                        if (filter == FilterType.NONE) handleNullFilter()
+                    }
+                })
+            }.show(parentFragmentManager, "FilterDialog")
+        }
+
+        binding.diaryArchiveFilterSearchBtn.setOnClickListener {
+            if (viewModel.filter.value == FilterType.NONE) {
+                // 필터가 NONE일 경우 토스트 메시지 표시
+                Toast.makeText(requireContext(), "필터를 선택해 주세요.", Toast.LENGTH_SHORT).show()
+            } else {
+                getDiaries()
+            }
+        }
+    }
+
+
+    fun handleNullFilter() {
+        viewModel.clearKeyword()
+        getDiaries()
+    }
 
     private fun getDiaries() {
         val adapter = DiaryRVAdapter(
@@ -122,18 +136,4 @@ class DiaryArchiveFragment: BaseFragment<FragmentDiaryArchiveBinding>(R.layout.f
     private fun onParticipantClickListener(participantsCount: Int, participantNames: String) {
         DiaryParticipantDialog(participantsCount, participantNames).show(parentFragmentManager, "ParticipantDialog")
     }
-
-
-    // yyyy.MM 타입을 밀리초로 변경
-    private fun convertYearMonthToMillis(
-        yearMonthStr: String,
-        pattern: String = "yyyy.MM"
-    ): Long = DateTimeFormat.forPattern(pattern).parseDateTime(yearMonthStr).toDate().time
-
-    companion object {
-        const val IS_MOIM = 1
-        const val IS_NOT_MOIM = 0
-    }
 }
-
-

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/home/diary/DiaryViewModel.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/home/diary/DiaryViewModel.kt
@@ -40,7 +40,7 @@ class DiaryViewModel @Inject constructor(
 
     /** 일기 리스트 조회 **/
     fun getDiaryPaging(): Flow<PagingData<Diary>> {
-        Log.d("getDiaryPaging", "filterType: ${_filter.value} keyword: ${keyword.value}")
+        Log.d("getDiaryPaging", "filterType: ${_filter.value?.request} keyword: ${keyword.value}")
         return repository.getDiaryArchivePagingSource(filter.value?.request, keyword.value)
             .cachedIn(viewModelScope)
             .map { it.insertHeaderLogic() }
@@ -67,6 +67,8 @@ class DiaryViewModel @Inject constructor(
     private fun Long.convertDate(): String {
         return SimpleDateFormat("yyyy.MM.dd").format(this * 1000)
     }
+
+    fun clearKeyword() { keyword.value = "" }
 
     fun setIsListEmpty(isEmpty: Boolean) { _isListEmpty.value = isEmpty }
 

--- a/app/src/main/res/layout/fragment_diary_archive.xml
+++ b/app/src/main/res/layout/fragment_diary_archive.xml
@@ -42,6 +42,9 @@
             android:layout_marginEnd="32dp"
             android:layout_marginTop="8dp"
             android:text="@={viewModel.keyword}"
+            android:inputType="text"
+            android:maxLength="8"
+            android:maxLines="1"
             app:layout_constraintEnd_toStartOf="@+id/diary_archive_filter_search_btn"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/diary_archive_filter" />


### PR DESCRIPTION
Related to: #351

## Related Issue
- #351

## Type of change
<!-- 작업의 종류를 선택해주세요. -->
- [x] Bug fix : 버그 수정

## PR Desciption
> 변경 사항 설명

https://github.com/user-attachments/assets/cccb049d-95de-49ff-bd7f-d729f35662c7

- 보관함 검색 필터 없이 검색 시 토스트 안내
- 보관함 검색 필터 없음 선택 시 키워드 초기화
- 보관함 키워드 줄바꿈 제한, inputType 지정

## Requirements for Reviewer
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

-

## PR Log

> PR 작업하면서 고민했던 내용, 해결한 내용, 고민 중인 내용 등

### 새롭게 배운 것

- 

### 고민 중인 사항

- 

## 첨부 자료

-
