### PR TITLE
[Fix/366] 모임 캘린더 스와이프 시 기존 달의 일정이 표시되던 이슈 해결

### DIFF
--- a/app/src/main/java/com/mongmong/namo/presentation/ui/community/calendar/CalendarViewModel.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/community/calendar/CalendarViewModel.kt
@@ -62,6 +62,7 @@ class CalendarViewModel @Inject constructor (
 
     /** 모임 캘린더 일정 조회 */
     fun getMoimCalendarSchedules() {
+        Log.d("CommunityCalVM", "getMoimCalendarSchedules()")
         viewModelScope.launch {
             // 범위로 일정 목록 조회
             _moimScheduleList.value = moimRepository.getMoimCalendarSchedules(
@@ -82,6 +83,11 @@ class CalendarViewModel @Inject constructor (
                 endDate = _monthDateList.last() // 캘린더에 표시되는 마지막 날짜
             )
         }
+    }
+
+    fun resetSchedule() {
+        _moimScheduleList.value = emptyList()
+        _friendScheduleList.value = emptyList()
     }
 
     /** 친구 카테고리 조회 */

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/community/calendar/CommunityCalendarMonthFragment.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/community/calendar/CommunityCalendarMonthFragment.kt
@@ -1,6 +1,7 @@
 package com.mongmong.namo.presentation.ui.community.calendar
 
 import android.os.Bundle
+import android.util.Log
 import androidx.fragment.app.activityViewModels
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.mongmong.namo.R
@@ -42,9 +43,15 @@ class CommunityCalendarMonthFragment : BaseFragment<FragmentCommunityCalendarMon
 
     override fun onResume() {
         super.onResume()
-
+        Log.d("CommunityCalFrag", "onResume()")
         setMonthCalendarSchedule()
         setAdapter()
+    }
+
+    override fun onPause() {
+        super.onPause()
+        Log.d("CommunityCalFrag", "onPause()")
+        viewModel.resetSchedule()
     }
 
     private fun initViews() {
@@ -86,7 +93,8 @@ class CommunityCalendarMonthFragment : BaseFragment<FragmentCommunityCalendarMon
                     }
                     viewModel.updateIsShow()
                 }
-
+                // 일정 데이터를 갱신하고 뷰를 다시 그리기
+                setMonthCalendarSchedule()
                 binding.communityCalendarMonthView.invalidate()
             }
         }
@@ -111,6 +119,7 @@ class CommunityCalendarMonthFragment : BaseFragment<FragmentCommunityCalendarMon
 
     // 캘린더에 표시할 월별 일정 조회
     private fun setMonthCalendarSchedule() {
+        Log.e("CommunityCalFrag", "setMonthCalendarSchedule - ${binding.communityCalendarMonthView.days[10]}")
         viewModel.setMonthDayList(binding.communityCalendarMonthView.days)
         if (viewModel.isFriendCalendar) {
             viewModel.getFriendCalendarSchedules() // 친구 캘린더 일정 조회 API 호출
@@ -134,13 +143,15 @@ class CommunityCalendarMonthFragment : BaseFragment<FragmentCommunityCalendarMon
     private fun initObserve() {
         viewModel.moimScheduleList.observe(viewLifecycleOwner) { scheduleList ->
             if (scheduleList != null) {
-                drawMonthCalendar(scheduleList.map { it.convertToCommunityModel() }) // 달력의 일정 표시
+                drawMonthCalendar(scheduleList.map { it.convertToCommunityModel() })
+                binding.communityCalendarMonthView.invalidate() // 뷰를 다시 그리기
             }
         }
 
         viewModel.friendScheduleList.observe(viewLifecycleOwner) { scheduleList ->
             if (scheduleList != null) {
-                drawMonthCalendar(scheduleList.map { it.convertToCommunityModel() }) // 달력의 일정 표시
+                drawMonthCalendar(scheduleList.map { it.convertToCommunityModel() })
+                binding.communityCalendarMonthView.invalidate() // 뷰를 다시 그리기
             }
         }
     }
@@ -152,6 +163,7 @@ class CommunityCalendarMonthFragment : BaseFragment<FragmentCommunityCalendarMon
     }
 
     private fun drawMonthCalendar(scheduleList: List<CommunityCommonSchedule>) {
+        Log.e("CommunityCalFrag", "drawMonthCalendar()")
         binding.communityCalendarMonthView.setCalendarType(viewModel.isFriendCalendar)
         binding.communityCalendarMonthView.setScheduleList(scheduleList)
 

--- a/app/src/main/java/com/mongmong/namo/presentation/ui/community/calendar/CommunityCalendarView.kt
+++ b/app/src/main/java/com/mongmong/namo/presentation/ui/community/calendar/CommunityCalendarView.kt
@@ -32,6 +32,8 @@ class CommunityCalendarView(context: Context, attrs: AttributeSet) :
             val startIdx = days.indexOf(parseLocalDateTimeToDateTime(scheduleList[i].startDate).withTimeAtStartOfDay())
             val endIdx = days.indexOf(parseLocalDateTimeToDateTime(scheduleList[i].endDate).withTimeAtStartOfDay())
 
+            if (startIdx == -1 || endIdx == -1) continue // 해당 달에 속하지 않는 일정은 무시
+
             for (splitSchedule in splitWeek(startIdx, endIdx)) {
                 val order = findMaxOrderInSchedule(splitSchedule.startIdx, splitSchedule.endIdx)
                 setOrder(order, splitSchedule.startIdx, splitSchedule.endIdx)
@@ -50,6 +52,8 @@ class CommunityCalendarView(context: Context, attrs: AttributeSet) :
         for (i in scheduleList.indices) {
             val startIdx = days.indexOf(parseLocalDateTimeToDateTime(scheduleList[i].startDate).withTimeAtStartOfDay())
             val endIdx = days.indexOf(parseLocalDateTimeToDateTime(scheduleList[i].endDate).withTimeAtStartOfDay())
+
+            if (startIdx == -1 || endIdx == -1) continue // 해당 달에 속하지 않는 일정은 무시
 
             for (splitSchedule in splitWeek(startIdx, endIdx)) {
                 val order = findMaxOrderInSchedule(splitSchedule.startIdx, splitSchedule.endIdx)


### PR DESCRIPTION
## Related Issue
- #366 

## Type of change
<!-- 작업의 종류를 선택해주세요. -->
- [ ] Feature : 새로운 기능 추가
- [x] Bug fix : 버그 수정
- [ ] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [ ] Style : 코드 스타일 및 포맷팅 작업
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## PR Desciption
> 변경 사항 설명
- 달력이 넘어가면 일정을 새로 표시하도록 코드를 수정했습니다.

https://github.com/user-attachments/assets/65254b41-4648-421c-beee-5c2a748ef558


## Requirements for Reviewer
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

-

## PR Log

> PR 작업하면서 고민했던 내용, 해결한 내용, 고민 중인 내용 등

### 새롭게 배운 것

- 

### 고민 중인 사항

- 

## 첨부 자료

-
